### PR TITLE
Add a provider subscription event type

### DIFF
--- a/idtype/idtype.go
+++ b/idtype/idtype.go
@@ -53,13 +53,17 @@ var (
 	Credential Type = 0x191
 
 	// Billing objects
-	BillingProfile    Type = 0x1F4
+	BillingProfile Type = 0x1F4
+
 	Trial             Type = 0x1F5
 	SubscriptionEvent Type = 0x1F6
 	Invoice           Type = 0x1F7 // Charges for users
 	InvoiceEvent      Type = 0x1F8 // record of payment or failure to pay
-	Payout            Type = 0x1F9 // Payouts for providers
-	PayoutEvent       Type = 0x1FA // record of payout of failure to payout
+
+	// A copy of a SubscriptionEvent recorded in the provider's event stream
+	ProviderSubscriptionEvent Type = 0x1F9
+	Payout                    Type = 0x1FA // Payouts for providers
+	PayoutEvent               Type = 0x1FB // record of payout of failure to payout
 
 	// Values from 0xF00 to 0x1000 are reserved for Manifold private internal
 	// only use.
@@ -170,6 +174,8 @@ func init() {
 	Register(SubscriptionEvent, false, "subscription_event")
 	Register(Invoice, false, "invoice")
 	Register(InvoiceEvent, false, "invoice_event")
+
+	Register(ProviderSubscriptionEvent, false, "provider_subscription_event")
 	Register(Payout, false, "payout")
 	Register(PayoutEvent, false, "payout_event")
 }


### PR DESCRIPTION
This will be a copy of and a reference to any subscription events that
would affect the provider, so we can keep a signed list of these, and
operate on them without inspecting all users.