### PR TITLE
Allow ID to have Empty values

### DIFF
--- a/id.go
+++ b/id.go
@@ -18,9 +18,6 @@ const (
 	byteLength = 18
 )
 
-// Comparator for empty IDs
-var emptyID [byteLength]byte
-
 // Identifiable is the interface implemented by objects that can be given
 // IDs.
 type Identifiable interface {
@@ -48,7 +45,7 @@ type Mutable interface {
 // The second byte holds the type of the object.
 // The remaining 16 bytes hold a digest of the contents of the object for
 // immutable objects, or a random value for mutable objects.
-type ID [byteLength]byte
+type ID []byte
 
 // NewMutableID returns a new ID for a mutable object.
 func NewMutableID(body Mutable) (ID, error) {
@@ -152,13 +149,17 @@ func (id ID) String() string {
 //
 // IDs are encoded in unpadded base32.
 func (id ID) MarshalJSON() ([]byte, error) {
-	return []byte("\"" + id.String() + "\""), nil
+	return []byte(`"` + id.String() + `"`), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for IDs.
 func (id *ID) UnmarshalJSON(b []byte) error {
 	if len(b) < 2 || b[0] != byte('"') || b[len(b)-1] != byte('"') {
 		return errors.New("value is not a string")
+	}
+
+	if id.IsEmpty() {
+		return nil
 	}
 
 	return id.fillID(b[1 : len(b)-1])
@@ -170,7 +171,7 @@ func (id *ID) fillID(raw []byte) error {
 		return err
 	}
 
-	copy(id[:], out)
+	copy((*id)[:], out)
 	return nil
 }
 
@@ -186,6 +187,21 @@ func decodeFromByte(raw []byte) ([]byte, error) {
 	return out, nil
 }
 
+// Equals compares two ids
+func (id ID) Equals(other ID) bool {
+	if len(id) != len(other) {
+		return false
+	}
+
+	for i := range id {
+		if id[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Validate implements the Validate interface for goswagger.
 // We know that if the value has successfully parsed, it is valid, so no action
 // is required.
@@ -195,5 +211,15 @@ func (id ID) Validate(_ interface{}) error {
 
 // IsEmpty returns whether or not the ID is empty (all zeros)
 func (id ID) IsEmpty() bool {
-	return id == emptyID
+	if len(id) == 0 {
+		return true
+	}
+
+	for _, b := range id {
+		if b != 0 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/id_test.go
+++ b/id_test.go
@@ -1,0 +1,61 @@
+package manifold
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/manifoldco/go-manifold/idtype"
+)
+
+func TestIDMarshalUnmarshal(t *testing.T) {
+	id, _ := NewID(idtype.User)
+
+	b, err := json.Marshal(id)
+	if err != nil {
+		t.Fatal("error marshaling", err)
+	}
+
+	var out ID
+	err = json.Unmarshal(b, &out)
+	if err != nil {
+		t.Fatal("error unmarshaling", err)
+	}
+
+	if id.Equals(out) {
+		t.Fatal("did not marshal/unmarshal correctly")
+	}
+}
+
+func TestIDOmitEmpty(t *testing.T) {
+	expected := `{}`
+
+	var in struct {
+		Field ID `json:",omitempty"`
+	}
+
+	b, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatal("error marshaling")
+	}
+
+	if string(b) != expected {
+		t.Fatal("value wasn't omitted. got", string(b))
+	}
+}
+
+func TestIDUnmarshalZeroLen(t *testing.T) {
+	in := `{"Field": "00000000000000000000000000000"}`
+
+	var out struct {
+		Field ID
+	}
+
+	err := json.Unmarshal([]byte(in), &out)
+	if err != nil {
+		t.Fatal("error during unmarshal: ", err.Error())
+	}
+
+	if len(out.Field) != 0 {
+		t.Fatal("did not unmarshal properly")
+	}
+}


### PR DESCRIPTION
The only Empty value for an array is one that is zero length.
Effectively this means that we can never have empty IDs that are omitted
by json serialization while they are arrays.

So, switch them to slices. This will break the API, as we can no longer
use `==` to compare two IDs; we'll have to use the new Equals method.