### PR TITLE
Makefile: fix up bootstrap tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ci: $(LINTERS) test
 
 BOOTSTRAP=\
 	github.com/golang/lint/golint \
-	honnef.co/go/simple/cmd/gosimple \
+	honnef.co/go/tools/cmd/gosimple \
 	github.com/client9/misspell/cmd/misspell \
 	github.com/gordonklaus/ineffassign \
 	github.com/tsenart/deadcode \


### PR DESCRIPTION
gosimple has changed it's path, we need to reflect this in our
bootstrapping tool.