### PR TITLE
Options: use WithAPIToken instead of WithAPIKey.

### DIFF
--- a/manifold.go
+++ b/manifold.go
@@ -54,13 +54,13 @@ func ForURLPattern(pattern string) ConfigFunc {
 	}
 }
 
-// WithAPIKey returns a configuration func to set the API key to use for
+// WithAPIToken returns a configuration func to set the API key to use for
 // authentication.
-func WithAPIKey(key string) ConfigFunc {
+func WithAPIToken(token string) ConfigFunc {
 	return func(c *Client) {
 		ot := c.client.Transport
 		c.client.Transport = rtFunc(func(r *http.Request) (*http.Response, error) {
-			r.Header.Set("Authorization", "Bearer "+key)
+			r.Header.Set("Authorization", "Bearer "+token)
 			return ot.RoundTrip(r)
 		})
 	}

--- a/manifold.go
+++ b/manifold.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/manifoldco/go-base64"
 )
@@ -34,6 +35,8 @@ func New(cfgs ...ConfigFunc) *Client {
 	c.MarketplaceClient.common.backend.(*defaultBackend).client = &c.client
 
 	ForURLPattern(DefaultURLPattern)(c)
+	WithAPIToken(os.Getenv("MANIFOLD_API_TOKEN"))(c)
+
 	for _, cfg := range cfgs {
 		cfg(c)
 	}


### PR DESCRIPTION
We're using APIToken in the CLI, let's use that in our client library as well.