### PR TITLE
Config: add WithUserAgent config option.

### DIFF
--- a/manifold.go
+++ b/manifold.go
@@ -41,6 +41,11 @@ func New(cfgs ...ConfigFunc) *Client {
 		cfg(c)
 	}
 
+	// We need to do this after we've set the configuration. In case someone
+	// provided a UserAgent, it will get loaded and overwrite our defaults since
+	// we re-assign the previous transport after this.
+	WithUserAgent("")(c)
+
 	return c
 }
 
@@ -64,6 +69,23 @@ func WithAPIToken(token string) ConfigFunc {
 		ot := c.client.Transport
 		c.client.Transport = rtFunc(func(r *http.Request) (*http.Response, error) {
 			r.Header.Set("Authorization", "Bearer "+token)
+			return ot.RoundTrip(r)
+		})
+	}
+}
+
+// WithUserAgent sets a specific user agent on the client. This will overwrite
+// any 'User-Agent' header that has been set before. We will prepend the
+// specified agent with `go-manifold-$version`.
+func WithUserAgent(agent string) ConfigFunc {
+	return func(c *Client) {
+		ot := c.client.Transport
+		c.client.Transport = rtFunc(func(r *http.Request) (*http.Response, error) {
+			if agent != "" {
+				agent = fmt.Sprintf(" (%s)", agent)
+			}
+
+			r.Header.Set("User-Agent", fmt.Sprintf("go-manifold-%s%s", Version, agent))
 			return ot.RoundTrip(r)
 		})
 	}

--- a/manifold.go
+++ b/manifold.go
@@ -35,7 +35,6 @@ func New(cfgs ...ConfigFunc) *Client {
 	c.MarketplaceClient.common.backend.(*defaultBackend).client = &c.client
 
 	ForURLPattern(DefaultURLPattern)(c)
-	WithAPIToken(os.Getenv("MANIFOLD_API_TOKEN"))(c)
 
 	for _, cfg := range cfgs {
 		cfg(c)
@@ -45,6 +44,7 @@ func New(cfgs ...ConfigFunc) *Client {
 	// provided a UserAgent, it will get loaded and overwrite our defaults since
 	// we re-assign the previous transport after this.
 	WithUserAgent("")(c)
+	WithAPIToken(os.Getenv("MANIFOLD_API_TOKEN"))(c)
 
 	return c
 }

--- a/manifold_test.go
+++ b/manifold_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	fmt "fmt"
 	http "net/http"
+	"os"
 	"testing"
 
 	manifold "github.com/manifoldco/go-manifold"
@@ -29,6 +30,31 @@ func TestConfig_WithUserAgent(t *testing.T) {
 
 		hct.reset()
 		hct.expectHeaderEquals(t, "User-Agent", fmt.Sprintf("%s (test)", defaultAgent))
+
+		c.Plans.List(context.Background(), nil)
+	})
+}
+
+func TestConfig_WithAPIToken(t *testing.T) {
+	hct := &headerCheckTransport{}
+	http.DefaultTransport = hct
+
+	token := os.Getenv("MANIFOLD_API_TOKEN")
+
+	t.Run("without extra configuration", func(t *testing.T) {
+		c := manifold.New()
+
+		hct.reset()
+		hct.expectHeaderEquals(t, "Authorization", fmt.Sprintf("Bearer %s", token))
+
+		c.Plans.List(context.Background(), nil)
+	})
+
+	t.Run("with extra configuration", func(t *testing.T) {
+		c := manifold.New(manifold.WithAPIToken("test-token"))
+
+		hct.reset()
+		hct.expectHeaderEquals(t, "Authorization", "Bearer test-token")
 
 		c.Plans.List(context.Background(), nil)
 	})

--- a/manifold_test.go
+++ b/manifold_test.go
@@ -1,0 +1,60 @@
+package manifold_test
+
+import (
+	context "context"
+	"errors"
+	fmt "fmt"
+	http "net/http"
+	"testing"
+
+	manifold "github.com/manifoldco/go-manifold"
+)
+
+func TestConfig_WithUserAgent(t *testing.T) {
+	hct := &headerCheckTransport{}
+	http.DefaultTransport = hct
+	defaultAgent := fmt.Sprintf("go-manifold-%s", manifold.Version)
+
+	t.Run("without extra configuration", func(t *testing.T) {
+		c := manifold.New()
+
+		hct.reset()
+		hct.expectHeaderEquals(t, "User-Agent", defaultAgent)
+
+		c.Plans.List(context.Background(), nil)
+	})
+
+	t.Run("with extra configuration", func(t *testing.T) {
+		c := manifold.New(manifold.WithUserAgent("test"))
+
+		hct.reset()
+		hct.expectHeaderEquals(t, "User-Agent", fmt.Sprintf("%s (test)", defaultAgent))
+
+		c.Plans.List(context.Background(), nil)
+	})
+}
+
+type headerCheckTransport struct {
+	t      *testing.T
+	checks map[string]string
+}
+
+func (hct *headerCheckTransport) reset() {
+	hct.checks = map[string]string{}
+}
+
+func (hct *headerCheckTransport) expectHeaderEquals(t *testing.T, key, value string) {
+	hct.t = t
+	hct.checks[key] = value
+}
+
+func (hct *headerCheckTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	for key, value := range hct.checks {
+		if r.Header.Get(key) != value {
+			hct.t.Errorf("Expected header '%s' to be '%s', got '%s')", key, value, r.Header.Get(key))
+		}
+	}
+
+	// return an error here so the test doesn't trip over nil values
+	return nil, errors.New("not successful")
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package manifold
+
+// Version is the package version of go-manifold.
+const Version = "0.8.3"


### PR DESCRIPTION
This adds the option to add a custom UserAgent to the client as well as
initializing a default UserAgent. This allows people to use tracking to see
how much the specific client is hitting their API.

The UserAgent will be in the format of `go-manifold-$version ($custom)`.