### PR TITLE
Releases: add auto tagging and versioning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,19 @@ $(LINTERS): vendor
 	$(METALINT) $@
 
 .PHONY: $(LINTERS) test
+
+#################################################
+# Releasing
+#################################################
+
+release:
+ifneq ($(shell git rev-parse --abbrev-ref HEAD),master)
+	$(error You are not on the master branch)
+endif
+ifndef VERSION
+	$(error You need to specify the version you want to tag)
+endif
+	cat version.go | sed -e 's|Version = ".*"|Version = "$(VERSION)"|' > version.go
+	git commit -m "Tagging v$(VERSION)"
+	git tag v$(VERSION)
+	git push --tags

--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ If you are a provider, you'll want to look at
 [grafton](https://github.com/manifoldco/grafton) for verifying your
 implementation, or [go-signature](https://github.com/manifoldco/go-signature)
 for verifying requests have come from Manifold instead.
+
+## Releasing
+
+To release a new version of this package, use the Make target `release`:
+
+```
+$ VERSION=0.1.2 make release
+```
+
+This will update the Version in `version.go`, commit the changes and set up a
+new tag.


### PR DESCRIPTION
This adds the ability to automatically tag and release a new version for
our package. This way it's always done in the same manner.