### PR TITLE
Add important release steps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,8 @@ ifndef VERSION
 	$(error You need to specify the version you want to tag)
 endif
 	cat version.go | sed -e 's|Version = ".*"|Version = "$(VERSION)"|' > version.go
+	git add .
 	git commit -m "Tagging v$(VERSION)"
 	git tag v$(VERSION)
+	git push
 	git push --tags


### PR DESCRIPTION
If you don't add files, you can't commit them.
git push --tags only pushes the tags, not the actual changes.