### PR TITLE
Set token client with env var if is present

### DIFF
--- a/manifold.go
+++ b/manifold.go
@@ -68,7 +68,9 @@ func WithAPIToken(token string) ConfigFunc {
 	return func(c *Client) {
 		ot := c.client.Transport
 		c.client.Transport = rtFunc(func(r *http.Request) (*http.Response, error) {
-			r.Header.Set("Authorization", "Bearer "+token)
+			if token != "" {
+				r.Header.Set("Authorization", "Bearer "+token)
+			}
 			return ot.RoundTrip(r)
 		})
 	}

--- a/manifold_test.go
+++ b/manifold_test.go
@@ -49,7 +49,12 @@ func TestConfig_WithAPIToken(t *testing.T) {
 	})
 
 	t.Run("with env var", func(t *testing.T) {
+		token := os.Getenv("MANIFOLD_API_TOKEN")
 		os.Setenv("MANIFOLD_API_TOKEN", "s3cr3t")
+
+		defer func() {
+			os.Setenv("MANIFOLD_API_TOKEN", token)
+		}()
 
 		c := manifold.New()
 

--- a/manifold_test.go
+++ b/manifold_test.go
@@ -39,13 +39,22 @@ func TestConfig_WithAPIToken(t *testing.T) {
 	hct := &headerCheckTransport{}
 	http.DefaultTransport = hct
 
-	token := os.Getenv("MANIFOLD_API_TOKEN")
-
 	t.Run("without extra configuration", func(t *testing.T) {
 		c := manifold.New()
 
 		hct.reset()
-		hct.expectHeaderEquals(t, "Authorization", fmt.Sprintf("Bearer %s", token))
+		hct.expectHeaderEquals(t, "Authorization", "")
+
+		c.Plans.List(context.Background(), nil)
+	})
+
+	t.Run("with env var", func(t *testing.T) {
+		os.Setenv("MANIFOLD_API_TOKEN", "s3cr3t")
+
+		c := manifold.New()
+
+		hct.reset()
+		hct.expectHeaderEquals(t, "Authorization", "Bearer s3cr3t")
 
 		c.Plans.List(context.Background(), nil)
 	})


### PR DESCRIPTION
This prevents the token being overwritten during the `.Login` request when a manual token is set.