### PR TITLE
Manifold: fix User-Agent with multiple calls.

### DIFF
--- a/manifold.go
+++ b/manifold.go
@@ -83,11 +83,12 @@ func WithUserAgent(agent string) ConfigFunc {
 	return func(c *Client) {
 		ot := c.client.Transport
 		c.client.Transport = rtFunc(func(r *http.Request) (*http.Response, error) {
+			nagent := agent
 			if agent != "" {
-				agent = fmt.Sprintf(" (%s)", agent)
+				nagent = fmt.Sprintf(" (%s)", nagent)
 			}
 
-			r.Header.Set("User-Agent", fmt.Sprintf("go-manifold-%s%s", Version, agent))
+			r.Header.Set("User-Agent", fmt.Sprintf("go-manifold-%s%s", Version, nagent))
 			return ot.RoundTrip(r)
 		})
 	}

--- a/manifold_test.go
+++ b/manifold_test.go
@@ -33,6 +33,25 @@ func TestConfig_WithUserAgent(t *testing.T) {
 
 		c.Plans.List(context.Background(), nil, nil)
 	})
+
+	t.Run("with multiple user agents", func(t *testing.T) {
+		c := manifold.New(manifold.WithUserAgent("test"), manifold.WithUserAgent("manifold"))
+
+		hct.reset()
+		hct.expectHeaderEquals(t, "User-Agent", fmt.Sprintf("%s (test)", defaultAgent))
+
+		c.Plans.List(context.Background(), nil, nil)
+	})
+
+	t.Run("with multiple calls - [GH 38]", func(t *testing.T) {
+		c := manifold.New(manifold.WithUserAgent("test"), manifold.WithUserAgent("manifold"))
+
+		hct.reset()
+		hct.expectHeaderEquals(t, "User-Agent", fmt.Sprintf("%s (test)", defaultAgent))
+
+		c.Plans.List(context.Background(), nil, nil)
+		c.Plans.List(context.Background(), nil, nil)
+	})
 }
 
 func TestConfig_WithAPIToken(t *testing.T) {
@@ -90,8 +109,8 @@ func (hct *headerCheckTransport) expectHeaderEquals(t *testing.T, key, value str
 
 func (hct *headerCheckTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	for key, value := range hct.checks {
-		if r.Header.Get(key) != value {
-			hct.t.Errorf("Expected header '%s' to be '%s', got '%s')", key, value, r.Header.Get(key))
+		if h := r.Header.Get(key); h != value {
+			hct.t.Errorf("Expected header '%s' to be '%s', got '%s')", key, value, h)
 		}
 	}
 


### PR DESCRIPTION
By not re-assigning the agent value, the original value gets overwritten
if it is not empty. This means that for multiple calls with the same
client, we'll end up with a chain of duplicated UserAgent strings.

To prevent this, we'll re-assign the value within the RoundTrip function
so it always starts with a "clean" value.

fixes https://github.com/manifoldco/go-manifold/issues/38