### PR TITLE
Fix panic on analytics properties

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-openapi/strfmt"
 	"github.com/manifoldco/go-manifold"
 	"github.com/manifoldco/go-manifold/errors"
@@ -634,6 +635,7 @@ func analyticsProperties(s interface{}) map[string]interface{} {
 	t := v.Type()
 
 	if v.Kind() != reflect.Struct {
+		spew.Dump(s)
 		return m
 	}
 

--- a/events/events.go
+++ b/events/events.go
@@ -633,11 +633,9 @@ func analyticsProperties(s interface{}) map[string]interface{} {
 	v := reflect.ValueOf(s).Elem()
 	t := v.Type()
 
-	/*
-		if v.Kind() != reflect.Struct {
-			return m
-		}
-	*/
+	if v.Kind() != reflect.Struct {
+		return m
+	}
 
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)

--- a/events/events.go
+++ b/events/events.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-openapi/strfmt"
 	"github.com/manifoldco/go-manifold"
 	"github.com/manifoldco/go-manifold/errors"
@@ -634,10 +633,11 @@ func analyticsProperties(s interface{}) map[string]interface{} {
 	v := reflect.ValueOf(s).Elem()
 	t := v.Type()
 
-	if v.Kind() != reflect.Struct {
-		spew.Dump(s)
-		return m
-	}
+	/*
+		if v.Kind() != reflect.Struct {
+			return m
+		}
+	*/
 
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)

--- a/events/events.go
+++ b/events/events.go
@@ -633,6 +633,10 @@ func analyticsProperties(s interface{}) map[string]interface{} {
 	v := reflect.ValueOf(s).Elem()
 	t := v.Type()
 
+	if v.Kind() != reflect.Struct {
+		return m
+	}
+
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
 

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -30,6 +30,7 @@ func TestAnalytics(t *testing.T) {
 					ID:   id,
 					Name: "local",
 				},
+				ProviderID: &id,
 				Provider: &Provider{
 					ID:   id,
 					Name: "Degraffdb",


### PR DESCRIPTION
We were trying to enumerate fields of non-struct data, ie: a `*manifold.ID`