### PR TITLE
Allow string method to be called on nil ID

### DIFF
--- a/id.go
+++ b/id.go
@@ -144,7 +144,11 @@ func (id ID) Type() idtype.Type {
 	return idtype.Decode(id[0]&0x0F, id[1])
 }
 
-func (id ID) String() string {
+func (id *ID) String() string {
+	if id == nil {
+		return ""
+	}
+
 	return base32.EncodeToString(id[:])
 }
 


### PR DESCRIPTION
This is useful for logging when a pointer to an ID maybe be nil.