### PR TITLE
Add GetProjectCredentials for fetching credentials by project

### DIFF
--- a/specs/marketplace.yaml
+++ b/specs/marketplace.yaml
@@ -274,10 +274,19 @@ paths:
           base32 encoded 18 byte identifier.
         collectionFormat: multi
         type: array
-        required: true
+        required: false
         items:
           format: base32ID
           type: string
+      - name: project_id
+        in: query
+        description: |
+          ID of the Project to filter Credentials by, stored as a
+          base32 encoded 18 byte identifier.
+        type: string
+        pattern: '^[0-9abcdefghjkmnpqrtuvwxyz]{29}$'
+        format: base32ID
+        required: false
       tags:
       - Credential
       responses:


### PR DESCRIPTION
This PR adds GetProjectCredentials which uses the `?project_id=` parameter for fetching project resource credentials, rather than `resource_ids=` . GetResourceCredentials still behaves as-is, even when given an optional project for drilling down.