### PR TITLE
NewProjectID, OldProjectID are *manifold.ID

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -486,11 +486,11 @@ type ResourceProjectChangedData struct {
 	PlanID *manifold.ID `json:"plan_id,omitempty"`
 	Plan   *Plan        `json:"plan,omitempty"`
 
-	OldProjectID manifold.ID `json:"old_project_id"`
-	OldProject   *Project    `json:"old_project,omitempty"`
+	OldProjectID *manifold.ID `json:"old_project_id"`
+	OldProject   *Project     `json:"old_project,omitempty"`
 
-	NewProjectID manifold.ID `json:"new_project_id"`
-	NewProject   *Project    `json:"new_project,omitempty"`
+	NewProjectID *manifold.ID `json:"new_project_id"`
+	NewProject   *Project     `json:"new_project,omitempty"`
 
 	RegionID *manifold.ID `json:"region_id,omitempty"`
 	Region   *Region      `json:"region,omitempty"`


### PR DESCRIPTION
Some resources that are being moved can belong to no projects, or are being moved out of a project, so the NewProjectID or OldProjectID would be nil in those cases.

Related manifoldco/engineering#5361