### PR TITLE
Fix reflection of unexported fields

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -600,7 +600,7 @@ func analyticsProperties(s interface{}) map[string]interface{} {
 
 		switch field.Kind() {
 		case reflect.Ptr:
-			if field.IsNil() {
+			if field.IsNil() || !field.CanInterface() {
 				continue
 			}
 

--- a/events/events.go
+++ b/events/events.go
@@ -3,6 +3,7 @@ package events
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"reflect"
 	"time"
 
@@ -601,6 +602,11 @@ func analyticsProperties(s interface{}) map[string]interface{} {
 		switch field.Kind() {
 		case reflect.Ptr:
 			if field.IsNil() {
+				continue
+			}
+
+			if !field.CanInterface() {
+				log.Printf("field: %v", field)
 				continue
 			}
 

--- a/events/events.go
+++ b/events/events.go
@@ -3,7 +3,6 @@ package events
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"reflect"
 	"time"
 
@@ -602,11 +601,6 @@ func analyticsProperties(s interface{}) map[string]interface{} {
 		switch field.Kind() {
 		case reflect.Ptr:
 			if field.IsNil() {
-				continue
-			}
-
-			if !field.CanInterface() {
-				log.Printf("field: %v", field)
 				continue
 			}
 

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/manifoldco/go-manifold"
 	"github.com/manifoldco/go-manifold/idtype"
@@ -30,15 +31,30 @@ func TestNew(t *testing.T) {
 
 func TestAnalytics(t *testing.T) {
 	id, _ := manifold.NewID(idtype.Resource)
+	uid, _ := manifold.NewID(idtype.User)
 	tid, _ := manifold.NewID(idtype.Team)
+	rid, _ := manifold.NewID(idtype.Resource)
 
 	event := Event{
+		ID:            id,
+		StructType:    "event",
+		StructVersion: 1,
 		Body: &OperationProvisioned{
 			BaseBody: BaseBody{
+				EventType: TypeOperationProvisioned,
+				StructActor: &Actor{
+					ID:    uid,
+					Name:  "luiz",
+					Email: "luiz@manifold.co",
+				},
 				StructScope: &Scope{
 					ID:   tid,
 					Name: "manifold",
 				},
+				StructRefID:     rid,
+				StructCreatedAt: time.Now(),
+				StructSource:    SourceSystem,
+				StructIPAddress: "127.0.01",
 			},
 			Data: &OperationProvisionedData{
 				Source: "catalog",


### PR DESCRIPTION
A panic was thrown if we tried to get an `.Interface()` of a private field, in this case it was the `time.Time` object.