### PR TITLE
Type for Metadata

### DIFF
--- a/number/number.go
+++ b/number/number.go
@@ -1,0 +1,73 @@
+package number
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// ToInt64 takes an interface and converts many things to int64 if able, returns error if it fails
+func ToInt64(val interface{}) (int64, error) {
+	switch v := val.(type) {
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case float32:
+		f := val.(float32)
+		i := int64(f)
+
+		if f != float32(i) {
+			return 0, errors.Errorf("invalid casting float32 (%f) to int64, precision loss detected", f)
+		}
+		return i, nil
+	case float64:
+		f := val.(float64)
+		i := int64(f)
+
+		if f != float64(i) {
+			return 0, errors.Errorf("invalid casting float64 (%f) to int64, precision loss detected", f)
+		}
+		return i, nil
+	case string:
+		return strconv.ParseInt(v, 10, 64)
+	case json.Number:
+		return v.Int64()
+	default:
+		return 0, fmt.Errorf("Unhandled type: %t", v)
+	}
+}
+
+// ToFloat64 takes an interface and converts many things to float64 if able, returns error if it fails
+func ToFloat64(val interface{}) (float64, error) {
+	switch v := val.(type) {
+	case int:
+		return float64(v), nil
+	case int8:
+		return float64(v), nil
+	case int16:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case float32:
+		return float64(v), nil
+	case float64:
+		return v, nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	case json.Number:
+		return v.Float64()
+	default:
+		return 0, fmt.Errorf("Unhandled type: %t", v)
+	}
+}

--- a/number/number_test.go
+++ b/number/number_test.go
@@ -1,0 +1,117 @@
+package number
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestToInt64(t *testing.T) {
+
+	tcs := []struct {
+		scenario string
+		in       interface{}
+		out      int64
+		err      string
+	}{
+		{scenario: "int8", in: int8(123), out: 123},
+		{scenario: "int16", in: int16(12345), out: 12345},
+		{scenario: "int32", in: int32(12345), out: 12345},
+		{scenario: "int64", in: int64(12345), out: 12345},
+		{scenario: "int", in: 12345, out: 12345},
+		{
+			scenario: "float32 doesn't lose precision",
+			in:       float32(12345),
+			out:      12345,
+		},
+		{
+			scenario: "float32 loses precision",
+			in:       float32(123.45),
+			err:      "invalid casting float32 (123.449997) to int64, precision loss detected",
+		},
+		{
+			scenario: "float64 doesn't lose precision",
+			in:       float64(12345),
+			out:      12345,
+		},
+		{
+			scenario: "float64 loses precision",
+			in:       float64(123.45),
+			err:      "invalid casting float64 (123.450000) to int64, precision loss detected",
+		},
+		{
+			scenario: "string",
+			in:       "12345",
+			out:      12345,
+		},
+		{
+			scenario: "json.Number",
+			in:       json.Number("12345"),
+			out:      12345,
+		},
+		{
+			scenario: "uint64",
+			in:       uint64(12345),
+			err:      fmt.Sprintf("Unhandled type: %t", interface{}(uint64(12345))),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.scenario, func(t *testing.T) {
+			out, err := ToInt64(tc.in)
+
+			if tc.err == "" {
+				if out != tc.out {
+					t.Errorf("Output %d did not match expected %d", out, tc.out)
+				}
+			} else {
+				if err.Error() != tc.err {
+					t.Errorf("Error '%s' did not match expected '%s'", err.Error(), tc.err)
+				}
+			}
+		})
+	}
+
+}
+
+func TestToFloat64(t *testing.T) {
+
+	tcs := []struct {
+		scenario string
+		in       interface{}
+		out      float64
+		err      string
+	}{
+		{scenario: "int8", in: int8(123), out: float64(123)},
+		{scenario: "int16", in: int16(12345), out: float64(12345)},
+		{scenario: "int32", in: int32(12345), out: float64(12345)},
+		{scenario: "int64", in: int64(12345), out: float64(12345)},
+		{scenario: "int", in: 12345, out: float64(12345)},
+		{scenario: "float32", in: float32(12345), out: float64(12345)},
+		{scenario: "float64", in: float64(12345), out: float64(12345)},
+		{scenario: "string", in: "12345", out: float64(12345)},
+		{scenario: "json.Number", in: json.Number("12345.5"), out: float64(12345.5)},
+		{
+			scenario: "uint64",
+			in:       uint64(12345),
+			err:      fmt.Sprintf("Unhandled type: %t", interface{}(uint64(12345))),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.scenario, func(t *testing.T) {
+			out, err := ToFloat64(tc.in)
+
+			if tc.err == "" {
+				if out != tc.out {
+					t.Errorf("Output %f did not match expected %f", out, tc.out)
+				}
+			} else {
+				if err.Error() != tc.err {
+					t.Errorf("Error '%s' did not match expected '%s'", err.Error(), tc.err)
+				}
+			}
+		})
+	}
+
+}

--- a/types.go
+++ b/types.go
@@ -2,17 +2,21 @@ package manifold
 
 import (
 	"encoding/json"
-	"reflect"
 
+	"github.com/manifoldco/go-manifold/number"
 	"github.com/pkg/errors"
 )
 
-func dataMapEquals(a map[string]interface{}, b map[string]interface{}) bool {
-	if len(a) != len(b) {
+// FeatureMap stores the selected feature values for a Manifold resource
+type FeatureMap map[string]interface{}
+
+// Equals checks the equality of another FeatureMap against this one
+func (f FeatureMap) Equals(fm FeatureMap) bool {
+	if len(f) != len(fm) {
 		return false
 	}
-	for k, v := range a {
-		if val, ok := b[k]; !ok || val != v {
+	for k, v := range f {
+		if val, ok := fm[k]; !ok || val != v {
 			return false
 		}
 	}
@@ -20,23 +24,164 @@ func dataMapEquals(a map[string]interface{}, b map[string]interface{}) bool {
 	return true
 }
 
-// FeatureMap stores the selected feature values for a Manifold resource
-type FeatureMap map[string]interface{}
+// MetadataValue stores MetadataValue for a Manifold resource
+type MetadataValue struct {
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
 
-// Equals checks the equality of another FeatureMap against this one
-func (f FeatureMap) Equals(fm FeatureMap) bool {
-	return dataMapEquals(f, fm)
+// Equals checks the equality of another MetadataValue against this one
+func (m *MetadataValue) Equals(md MetadataValue) bool {
+	return m.Type == md.Type && m.Value == md.Value
+}
+
+func (m *MetadataValue) tryCastFields() error {
+	switch m.Type {
+	case "string":
+		_, ok := m.Value.(string)
+		if !ok {
+			return errors.New("Expected value to be a string but it was not")
+		}
+	case "bool":
+		_, ok := m.Value.(bool)
+		if !ok {
+			return errors.New("Expected value to be a boolean but it was not")
+		}
+	case "int":
+		val, err := number.ToInt64(m.Value)
+		if err != nil {
+			return errors.Errorf(
+				"Expected value to be castable to int64 but it was not: %s", err.Error())
+		}
+		m.Value = val
+	case "float":
+		val, err := number.ToFloat64(m.Value)
+		if err != nil {
+			return errors.Errorf(
+				"Expected value to be castable to float64 but it was not: %s", err.Error())
+		}
+		m.Value = val
+	case "object":
+		val, ok := m.Value.(Metadata)
+		if !ok {
+			valMap, ok := m.Value.(map[string]interface{})
+			if !ok {
+				return errors.Errorf("Expected value to be a valid metadata object but it was not")
+			}
+			val = Metadata{}
+			for k, v := range valMap {
+				vMap, ok := v.(map[string]interface{})
+				if !ok {
+					return errors.Errorf(
+						"Expected value to be a valid metadata object but it's values aren't compatible")
+				}
+				kv := MetadataValue{}
+				if err := kv.FromMap(vMap); err != nil {
+					return errors.Errorf(
+						"Expected value to be a valid metadata object but it was not: %s", err.Error())
+				}
+				val[k] = kv
+			}
+		}
+		m.Value = val
+	default:
+		return errors.Errorf(
+			"%s is not a valid type, expected 'string', 'int', 'float', 'bool', or 'object", m.Type)
+	}
+	return nil
+}
+
+// FromMap tries to make a MetadataValue from a supplied map
+func (m *MetadataValue) FromMap(md map[string]interface{}) error {
+	typI, ok := md["type"]
+	if !ok {
+		return errors.New("Could not make MetadataValue from map, it did not contain a 'type' key")
+	}
+	typ, ok := typI.(string)
+	if !ok {
+		return errors.New("Could not make MetadataValue from map, the type key was not a string as expected")
+	}
+	val, ok := md["value"]
+	if !ok {
+		return errors.New("Could not make MetadataValue from map, it did not contain a 'value' key")
+	}
+	m.Type = typ
+	m.Value = val
+	if err := m.tryCastFields(); err != nil {
+		return errors.Errorf("Could not make MetadataValue from map: %s", err.Error())
+	}
+	return nil
+}
+
+// UnmarshalJSON controls how a MetadataValue is parsed from JSON
+func (m *MetadataValue) UnmarshalJSON(data []byte) error {
+	mv := &struct {
+		Type  string      `json:"type"`
+		Value interface{} `json:"value"`
+	}{}
+	json.Unmarshal(data, &mv)
+	m.Type = mv.Type
+	m.Value = mv.Value
+	return m.tryCastFields()
+}
+
+// Validate validates this MetadataValue
+func (m *MetadataValue) Validate(_ interface{}) error {
+	switch m.Type {
+	case "string":
+		_, ok := m.Value.(string)
+		if !ok {
+			return errors.New("Expected value to be a string but it was not")
+		}
+	case "int":
+		_, ok := m.Value.(int64)
+		if !ok {
+			return errors.New("Expected value to be a int64 but it was not")
+		}
+	case "float":
+		_, ok := m.Value.(float64)
+		if !ok {
+			return errors.New("Expected value to be a float64 but it was not")
+		}
+	case "bool":
+		_, ok := m.Value.(bool)
+		if !ok {
+			return errors.New("Expected value to be a bool but it was not")
+		}
+	case "object":
+		val, ok := m.Value.(Metadata)
+		if !ok {
+			return errors.New("Expected value to be a Metadata but it was not")
+		}
+		err := val.Validate(nil)
+		if err != nil {
+			return errors.Errorf("Metadata value was not valid: %s", err.Error())
+		}
+	default:
+		return errors.Errorf(
+			"%s is not a valid type, expected 'string', 'int', 'float', 'bool', or 'object", m.Type)
+	}
+	return nil
 }
 
 // Metadata stores Metadata for a Manifold resource
-type Metadata map[string]interface{}
+type Metadata map[string]MetadataValue
 
 // MetadataMaxSize defines the max size of the metadata JSON in bytes
-const MetadataMaxSize = 1024
+const MetadataMaxSize = 10 * 1024
 
 // Equals checks the equality of another Metadata against this one
 func (m Metadata) Equals(md Metadata) bool {
-	return dataMapEquals(m, md)
+	if len(m) != len(md) {
+		return false
+	}
+	for k, v := range m {
+		if val, ok := md[k]; !ok || !val.Equals(v) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Validate validates this Metadata
@@ -46,22 +191,9 @@ func (m Metadata) Validate(_ interface{}) error {
 		if err := Label(k).Validate(nil); err != nil {
 			return errors.Errorf("Key '%s' is not a valid Manifold Label", k)
 		}
-		// Make sure value is an allowed type
-		switch t := v.(type) {
-		case string, bool, float32, float64, int, int8, int16, int32, int64, uint,
-			uint8, uint16, uint32, uint64, json.Number:
-			continue
-		case map[string]interface{}:
-			if err := Metadata(t).Validate(nil); err != nil {
-				return err
-			}
-		case Metadata:
-			if err := t.Validate(nil); err != nil {
-				return err
-			}
-		default:
-			typ := reflect.TypeOf(v)
-			return errors.Errorf("'%s' is an invalid field value type for Metadata", typ.Name())
+		// Make sure value is valid
+		if err := v.Validate(nil); err != nil {
+			return errors.Errorf("Value of key '%s' is not valid: %s", k, err.Error())
 		}
 	}
 	// Make sure total length isn't too long

--- a/types.go
+++ b/types.go
@@ -1,18 +1,75 @@
 package manifold
 
-// FeatureMap stores the selected feature values for a Manifold resource
-type FeatureMap map[string]interface{}
+import (
+	"encoding/json"
+	"reflect"
 
-// Equals checks the equality of another FeatureMap against this one
-func (f FeatureMap) Equals(fm FeatureMap) bool {
-	if len(f) != len(fm) {
+	"github.com/pkg/errors"
+)
+
+func dataMapEquals(a map[string]interface{}, b map[string]interface{}) bool {
+	if len(a) != len(b) {
 		return false
 	}
-	for k, v := range f {
-		if val, ok := fm[k]; !ok || val != v {
+	for k, v := range a {
+		if val, ok := b[k]; !ok || val != v {
 			return false
 		}
 	}
 
 	return true
+}
+
+// FeatureMap stores the selected feature values for a Manifold resource
+type FeatureMap map[string]interface{}
+
+// Equals checks the equality of another FeatureMap against this one
+func (f FeatureMap) Equals(fm FeatureMap) bool {
+	return dataMapEquals(f, fm)
+}
+
+// Metadata stores Metadata for a Manifold resource
+type Metadata map[string]interface{}
+
+// MetadataMaxSize defines the max size of the metadata JSON in bytes
+const MetadataMaxSize = 1024
+
+// Equals checks the equality of another Metadata against this one
+func (m Metadata) Equals(md Metadata) bool {
+	return dataMapEquals(m, md)
+}
+
+// Validate validates this Metadata
+func (m Metadata) Validate(_ interface{}) error {
+	for k, v := range m {
+		// Make sure key is a label
+		if err := Label(k).Validate(nil); err != nil {
+			return errors.Errorf("Key '%s' is not a valid Manifold Label", k)
+		}
+		// Make sure value is an allowed type
+		switch t := v.(type) {
+		case string, bool, float32, float64, int, int8, int16, int32, int64, uint,
+			uint8, uint16, uint32, uint64, json.Number:
+			continue
+		case map[string]interface{}:
+			if err := Metadata(t).Validate(nil); err != nil {
+				return err
+			}
+		case Metadata:
+			if err := t.Validate(nil); err != nil {
+				return err
+			}
+		default:
+			typ := reflect.TypeOf(v)
+			return errors.Errorf("'%s' is an invalid field value type for Metadata", typ.Name())
+		}
+	}
+	// Make sure total length isn't too long
+	b, _ := json.Marshal(m)
+	bLen := len(b)
+	if bLen > MetadataMaxSize {
+		return errors.Errorf("%d is %d bytes larger than the Metadata size limit of %d",
+			bLen, MetadataMaxSize-bLen, MetadataMaxSize)
+	}
+	return nil
 }

--- a/types.go
+++ b/types.go
@@ -187,7 +187,7 @@ type Metadata map[string]MetadataValue
 // MetadataMaxSize defines the max size of the metadata JSON in bytes
 const MetadataMaxSize = 10 * 1024
 
-// ErrMetadataNonexistantKey decribes and error for when the expected key is not present
+// ErrMetadataNonexistantKey describes and error for when the expected key is not present
 var ErrMetadataNonexistantKey = errors.New("Key does not exist")
 
 // ErrMetadataUnexpectedValueType describes and error when a metadata type isn't what's expected

--- a/types_test.go
+++ b/types_test.go
@@ -1,6 +1,7 @@
 package manifold
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -48,4 +49,124 @@ func TestFeatureMap(t *testing.T) {
 			t.Error("A and B are equal, but aren't.")
 		}
 	})
+}
+
+func TestMetadata(t *testing.T) {
+	t.Run("different Metadata are not equal", func(t *testing.T) {
+		a := Metadata{
+			"abra":       1,
+			"bulbasaur":  "TWO",
+			"charmander": false,
+		}
+		b := Metadata{
+			"abra":       2,
+			"bulbasaur":  "one",
+			"charmander": true,
+		}
+		c := Metadata{
+			"abra":      1,
+			"bulbasaur": "TWO",
+		}
+
+		if a.Equals(b) {
+			t.Error("A and B are not equal, but are.")
+		}
+		if b.Equals(c) {
+			t.Error("B and C are not equal, but are.")
+		}
+		if a.Equals(c) {
+			t.Error("A and C are not equal, but are.")
+		}
+	})
+
+	t.Run("Metadata with the same values are equal", func(t *testing.T) {
+		a := Metadata{
+			"abra":       1,
+			"bulbasaur":  "TWO",
+			"charmander": false,
+		}
+		b := Metadata{
+			"abra":       1,
+			"bulbasaur":  "TWO",
+			"charmander": false,
+		}
+
+		if !a.Equals(b) {
+			t.Error("A and B are equal, but aren't.")
+		}
+	})
+
+	t.Run("Expected Metadata is considered valid", func(t *testing.T) {
+		mds := []Metadata{
+			Metadata{
+				"abra":       1,
+				"bulbasaur":  "TWO",
+				"charmander": false,
+			},
+			Metadata{
+				"abra":       1,
+				"bulbasaur":  "TWO",
+				"charmander": false,
+				"subdata": Metadata{
+					"abra":       1,
+					"bulbasaur":  "TWO",
+					"charmander": false,
+				},
+			},
+			Metadata{
+				"abra":       1,
+				"bulbasaur":  "TWO",
+				"charmander": false,
+				"subdata": map[string]interface{}{
+					"abra":       1,
+					"bulbasaur":  "TWO",
+					"charmander": false,
+				},
+			},
+		}
+
+		for _, m := range mds {
+			if err := m.Validate(nil); err != nil {
+				t.Error(err)
+			}
+		}
+	})
+
+	t.Run("Expected Metadata is considered invalid", func(t *testing.T) {
+		mds := []Metadata{
+			Metadata{
+				"$$$BADLABEL$$": 1,
+			},
+			Metadata{
+				"bad-value-type": json.Encoder{},
+			},
+			Metadata{
+				"nested-value-err": Metadata{
+					"$$$BADLABEL$$": 1,
+				},
+			},
+			Metadata{
+				"nested-value-err": map[string]interface{}{
+					"$$$BADLABEL$$": 1,
+				},
+			},
+			Metadata{
+				"json-too-big": makeBigString(MetadataMaxSize),
+			},
+		}
+
+		for _, m := range mds {
+			if err := m.Validate(nil); err == nil {
+				t.Errorf("Expected error for Metadata case: %v", m)
+			}
+		}
+	})
+}
+
+func makeBigString(size int) string {
+	b := make([]byte, size)
+	for i := 0; i < size; i++ {
+		b[i] = 'a'
+	}
+	return string(b)
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1,12 +1,12 @@
 package manifold
 
 import (
-	"encoding/json"
+	json "encoding/json"
 	"testing"
 )
 
 func TestFeatureMap(t *testing.T) {
-	t.Run("different FeatureMaps are not equal", func(t *testing.T) {
+	t.Run("Different FeatureMaps are not equal", func(t *testing.T) {
 		a := FeatureMap{
 			"a": 1,
 			"b": "TWO",
@@ -23,13 +23,13 @@ func TestFeatureMap(t *testing.T) {
 		}
 
 		if a.Equals(b) {
-			t.Error("A and B are not equal, but are.")
+			t.Error("Expected A to not eqaul B, but it did.")
 		}
 		if b.Equals(c) {
-			t.Error("B and C are not equal, but are.")
+			t.Error("Expected B to not eqaul C, but it did.")
 		}
 		if a.Equals(c) {
-			t.Error("A and C are not equal, but are.")
+			t.Error("Expected A to not eqaul C, but it did.")
 		}
 	})
 
@@ -46,82 +46,72 @@ func TestFeatureMap(t *testing.T) {
 		}
 
 		if !a.Equals(b) {
-			t.Error("A and B are equal, but aren't.")
+			t.Error("Expected A to eqaul B, but it didn't.")
 		}
 	})
 }
 
 func TestMetadata(t *testing.T) {
-	t.Run("different Metadata are not equal", func(t *testing.T) {
+	t.Run("Different Metadata are not equal", func(t *testing.T) {
 		a := Metadata{
-			"abra":       1,
-			"bulbasaur":  "TWO",
-			"charmander": false,
+			"abra":       {Type: "int", Value: 1},
+			"bulbasaur":  {Type: "string", Value: "TWO"},
+			"charmander": {Type: "bool", Value: false},
 		}
 		b := Metadata{
-			"abra":       2,
-			"bulbasaur":  "one",
-			"charmander": true,
+			"abra":       {Type: "int", Value: 2},
+			"bulbasaur":  {Type: "string", Value: "one"},
+			"charmander": {Type: "bool", Value: true},
 		}
 		c := Metadata{
-			"abra":      1,
-			"bulbasaur": "TWO",
+			"abra":      {Type: "int", Value: 1},
+			"bulbasaur": {Type: "string", Value: "TWO"},
 		}
 
 		if a.Equals(b) {
-			t.Error("A and B are not equal, but are.")
+			t.Error("Expected A to not eqaul B, but it did.")
 		}
 		if b.Equals(c) {
-			t.Error("B and C are not equal, but are.")
+			t.Error("Expected B to not eqaul C, but it did.")
 		}
 		if a.Equals(c) {
-			t.Error("A and C are not equal, but are.")
+			t.Error("Expected A to not eqaul C, but it did.")
 		}
 	})
 
 	t.Run("Metadata with the same values are equal", func(t *testing.T) {
 		a := Metadata{
-			"abra":       1,
-			"bulbasaur":  "TWO",
-			"charmander": false,
+			"abra":       {Type: "int", Value: 1},
+			"bulbasaur":  {Type: "string", Value: "TWO"},
+			"charmander": {Type: "bool", Value: false},
 		}
 		b := Metadata{
-			"abra":       1,
-			"bulbasaur":  "TWO",
-			"charmander": false,
+			"abra":       {Type: "int", Value: 1},
+			"bulbasaur":  {Type: "string", Value: "TWO"},
+			"charmander": {Type: "bool", Value: false},
 		}
 
 		if !a.Equals(b) {
-			t.Error("A and B are equal, but aren't.")
+			t.Error("Expected A to eqaul B, but it didn't.")
 		}
 	})
 
 	t.Run("Expected Metadata is considered valid", func(t *testing.T) {
 		mds := []Metadata{
 			{
-				"abra":       1,
-				"bulbasaur":  "TWO",
-				"charmander": false,
+				"abra":       {Type: "int", Value: int64(1)},
+				"bulbasaur":  {Type: "string", Value: "TWO"},
+				"charmander": {Type: "bool", Value: false},
 			},
 			{
-				"abra":       1,
-				"bulbasaur":  "TWO",
-				"charmander": false,
-				"subdata": Metadata{
-					"abra":       1,
-					"bulbasaur":  "TWO",
-					"charmander": false,
-				},
-			},
-			{
-				"abra":       1,
-				"bulbasaur":  "TWO",
-				"charmander": false,
-				"subdata": map[string]interface{}{
-					"abra":       1,
-					"bulbasaur":  "TWO",
-					"charmander": false,
-				},
+				"abra":       {Type: "int", Value: int64(1)},
+				"bulbasaur":  {Type: "string", Value: "TWO"},
+				"charmander": {Type: "bool", Value: false},
+				"subdata": {Type: "object", Value: Metadata{
+					"abra":       {Type: "int", Value: int64(1)},
+					"bulbasaur":  {Type: "string", Value: "TWO"},
+					"charmander": {Type: "bool", Value: false},
+				}},
 			},
 		}
 
@@ -135,23 +125,18 @@ func TestMetadata(t *testing.T) {
 	t.Run("Expected Metadata is considered invalid", func(t *testing.T) {
 		mds := []Metadata{
 			{
-				"$$$BADLABEL$$": 1,
+				"$$$BADLABEL$$": {Type: "int", Value: int64(1)},
 			},
 			{
-				"bad-value-type": json.Encoder{},
+				"bad-value-type": {Type: "int", Value: "NOTANINT"},
 			},
 			{
-				"nested-value-err": Metadata{
-					"$$$BADLABEL$$": 1,
-				},
+				"nested-value-err": {Type: "object", Value: Metadata{
+					"$$$BADLABEL$$": {Type: "int", Value: int64(1)},
+				}},
 			},
 			{
-				"nested-value-err": map[string]interface{}{
-					"$$$BADLABEL$$": 1,
-				},
-			},
-			{
-				"json-too-big": makeBigString(MetadataMaxSize),
+				"json-too-big": {Type: "string", Value: makeBigString(MetadataMaxSize)},
 			},
 		}
 
@@ -169,4 +154,65 @@ func makeBigString(size int) string {
 		b[i] = 'a'
 	}
 	return string(b)
+}
+
+func TestMetadataValue(t *testing.T) {
+
+	t.Run("UnmarshalJSON is successful when expected", func(t *testing.T) {
+		JSONs := []string{
+			`{ "type": "string", "value": "this is a string" }`,
+			`{ "type": "bool", "value": false }`,
+			`{ "type": "int", "value": 12 }`,
+			`{ "type": "float", "value": 12.2 }`,
+			`{ "type": "object", "value": {  
+				"sub-object-key": { "type": "int", "value": 7 }
+			 } }`,
+		}
+
+		for _, j := range JSONs {
+			mdv := &MetadataValue{}
+			if err := json.Unmarshal([]byte(j), &mdv); err != nil {
+				t.Error(err)
+			}
+			if err := mdv.Validate(nil); err != nil {
+				t.Error(err)
+			}
+		}
+	})
+
+	t.Run("UnmarshalJSON errors when expected", func(t *testing.T) {
+		JSONs := []string{
+			`{ "type": "string", "value": false }`,
+			`{ "type": "bool", "value": 1 }`,
+			`{ "type": "int", "value": false }`,
+			`{ "type": "float", "value": false }`,
+			`{ "type": "object", "value": false }`,
+			`{ "type": "snake", "value": false }`,
+			`{ "type": "object", "value": {  
+				"sub-object-key": false
+			 } }`,
+			`{ "type": "object", "value": {  
+				"sub-object-key": { "value": false }
+			 } }`,
+			`{ "type": "object", "value": {  
+				"sub-object-key": { "type": false, "value": 7 }
+			 } }`,
+			`{ "type": "object", "value": {  
+				"sub-object-key": { "type": "object" }
+			 } }`,
+			`{ "type": "object", "value": {  
+				"sub-object-key": { "type": "snake", "value": false }
+			 } }`,
+		}
+
+		for _, j := range JSONs {
+			mdv := &MetadataValue{}
+			if err := json.Unmarshal([]byte(j), &mdv); err == nil {
+				t.Errorf("Expected err for Unmarshal of: %s", j)
+			}
+			if err := mdv.Validate(nil); err == nil {
+				t.Errorf("Expected err for Validate of: %s", j)
+			}
+		}
+	})
 }

--- a/types_test.go
+++ b/types_test.go
@@ -54,18 +54,18 @@ func TestFeatureMap(t *testing.T) {
 func TestMetadata(t *testing.T) {
 	t.Run("Different Metadata are not equal", func(t *testing.T) {
 		a := Metadata{
-			"abra":       {Type: "int", Value: 1},
-			"bulbasaur":  {Type: "string", Value: "TWO"},
-			"charmander": {Type: "bool", Value: false},
+			"abra":       {Type: MetadataValueTypeInt, Value: 1},
+			"bulbasaur":  {Type: MetadataValueTypeString, Value: "TWO"},
+			"charmander": {Type: MetadataValueTypeBool, Value: false},
 		}
 		b := Metadata{
-			"abra":       {Type: "int", Value: 2},
-			"bulbasaur":  {Type: "string", Value: "one"},
-			"charmander": {Type: "bool", Value: true},
+			"abra":       {Type: MetadataValueTypeInt, Value: 2},
+			"bulbasaur":  {Type: MetadataValueTypeString, Value: "one"},
+			"charmander": {Type: MetadataValueTypeBool, Value: true},
 		}
 		c := Metadata{
-			"abra":      {Type: "int", Value: 1},
-			"bulbasaur": {Type: "string", Value: "TWO"},
+			"abra":      {Type: MetadataValueTypeInt, Value: 1},
+			"bulbasaur": {Type: MetadataValueTypeString, Value: "TWO"},
 		}
 
 		if a.Equals(b) {
@@ -81,14 +81,14 @@ func TestMetadata(t *testing.T) {
 
 	t.Run("Metadata with the same values are equal", func(t *testing.T) {
 		a := Metadata{
-			"abra":       {Type: "int", Value: 1},
-			"bulbasaur":  {Type: "string", Value: "TWO"},
-			"charmander": {Type: "bool", Value: false},
+			"abra":       {Type: MetadataValueTypeInt, Value: 1},
+			"bulbasaur":  {Type: MetadataValueTypeString, Value: "TWO"},
+			"charmander": {Type: MetadataValueTypeBool, Value: false},
 		}
 		b := Metadata{
-			"abra":       {Type: "int", Value: 1},
-			"bulbasaur":  {Type: "string", Value: "TWO"},
-			"charmander": {Type: "bool", Value: false},
+			"abra":       {Type: MetadataValueTypeInt, Value: 1},
+			"bulbasaur":  {Type: MetadataValueTypeString, Value: "TWO"},
+			"charmander": {Type: MetadataValueTypeBool, Value: false},
 		}
 
 		if !a.Equals(b) {
@@ -99,18 +99,18 @@ func TestMetadata(t *testing.T) {
 	t.Run("Expected Metadata is considered valid", func(t *testing.T) {
 		mds := []Metadata{
 			{
-				"abra":       {Type: "int", Value: int64(1)},
-				"bulbasaur":  {Type: "string", Value: "TWO"},
-				"charmander": {Type: "bool", Value: false},
+				"abra":       {Type: MetadataValueTypeInt, Value: int64(1)},
+				"bulbasaur":  {Type: MetadataValueTypeString, Value: "TWO"},
+				"charmander": {Type: MetadataValueTypeBool, Value: false},
 			},
 			{
-				"abra":       {Type: "int", Value: int64(1)},
-				"bulbasaur":  {Type: "string", Value: "TWO"},
-				"charmander": {Type: "bool", Value: false},
-				"subdata": {Type: "object", Value: Metadata{
-					"abra":       {Type: "int", Value: int64(1)},
-					"bulbasaur":  {Type: "string", Value: "TWO"},
-					"charmander": {Type: "bool", Value: false},
+				"abra":       {Type: MetadataValueTypeInt, Value: int64(1)},
+				"bulbasaur":  {Type: MetadataValueTypeString, Value: "TWO"},
+				"charmander": {Type: MetadataValueTypeBool, Value: false},
+				"subdata": {Type: MetadataValueTypeObject, Value: Metadata{
+					"abra":       {Type: MetadataValueTypeInt, Value: int64(1)},
+					"bulbasaur":  {Type: MetadataValueTypeString, Value: "TWO"},
+					"charmander": {Type: MetadataValueTypeBool, Value: false},
 				}},
 			},
 		}
@@ -125,18 +125,18 @@ func TestMetadata(t *testing.T) {
 	t.Run("Expected Metadata is considered invalid", func(t *testing.T) {
 		mds := []Metadata{
 			{
-				"$$$BADLABEL$$": {Type: "int", Value: int64(1)},
+				"$$$BADLABEL$$": {Type: MetadataValueTypeInt, Value: int64(1)},
 			},
 			{
-				"bad-value-type": {Type: "int", Value: "NOTANINT"},
+				"bad-value-type": {Type: MetadataValueTypeInt, Value: "NOTANINT"},
 			},
 			{
-				"nested-value-err": {Type: "object", Value: Metadata{
-					"$$$BADLABEL$$": {Type: "int", Value: int64(1)},
+				"nested-value-err": {Type: MetadataValueTypeObject, Value: Metadata{
+					"$$$BADLABEL$$": {Type: MetadataValueTypeInt, Value: int64(1)},
 				}},
 			},
 			{
-				"json-too-big": {Type: "string", Value: makeBigString(MetadataMaxSize)},
+				"json-too-big": {Type: MetadataValueTypeString, Value: makeBigString(MetadataMaxSize)},
 			},
 		}
 
@@ -144,6 +144,115 @@ func TestMetadata(t *testing.T) {
 			if err := m.Validate(nil); err == nil {
 				t.Errorf("Expected error for Metadata case: %v", m)
 			}
+		}
+	})
+
+	t.Run("HasType functions, function as expected", func(t *testing.T) {
+		m := Metadata{
+			"int":    {Type: MetadataValueTypeInt, Value: int64(1)},
+			"float":  {Type: MetadataValueTypeFloat, Value: float64(1.23)},
+			"string": {Type: MetadataValueTypeString, Value: "izzastring"},
+			"bool":   {Type: MetadataValueTypeBool, Value: false},
+			"object": {Type: MetadataValueTypeObject, Value: Metadata{
+				"abra":    {Type: MetadataValueTypeInt, Value: int64(1)},
+				"kadabra": {Type: MetadataValueTypeInt, Value: int64(2)},
+			}},
+		}
+		expectFailFuncs := map[MetadataValueType]func(string){
+			MetadataValueTypeInt: func(k string) {
+				iVal, err := m.GetInt(k)
+				if iVal != nil || err != ErrMetadataUnexpectedValueType {
+					t.Errorf("Expected unexpected value type error for Metadata GetInt, got (%v),(%v)", iVal, err)
+				}
+			},
+			MetadataValueTypeFloat: func(k string) {
+				fVal, err := m.GetFloat(k)
+				if fVal != nil || err != ErrMetadataUnexpectedValueType {
+					t.Errorf("Expected unexpected value type error for Metadata GetFloat, got (%v),(%v)", fVal, err)
+				}
+			},
+			MetadataValueTypeString: func(k string) {
+				sVal, err := m.GetString(k)
+				if sVal != nil || err != ErrMetadataUnexpectedValueType {
+					t.Errorf("Expected unexpected value type error for Metadata GetString, got (%v),(%v)", sVal, err)
+				}
+			},
+			MetadataValueTypeBool: func(k string) {
+				bVal, err := m.GetBool(k)
+				if bVal != nil || err != ErrMetadataUnexpectedValueType {
+					t.Errorf("Expected unexpected value type error for Metadata GetBool, got (%v),(%v)", bVal, err)
+				}
+			},
+			MetadataValueTypeObject: func(k string) {
+				oVal, err := m.GetObject(k)
+				if oVal != nil || err != ErrMetadataUnexpectedValueType {
+					t.Errorf("Expected unexpected value type error for Metadata GetObject, got (%v),(%v)", oVal, err)
+				}
+			},
+		}
+
+		for k, v := range m {
+			switch v.Type {
+			case MetadataValueTypeInt:
+				iVal, err := m.GetInt(k)
+				if iVal == nil || err != nil {
+					t.Errorf("Expected no error for Metadata GetInt, got (%v),(%v)", iVal, err)
+				}
+			case MetadataValueTypeFloat:
+				fVal, err := m.GetFloat(k)
+				if fVal == nil || err != nil {
+					t.Errorf("Expected no error for Metadata GetFloat, got (%v),(%v)", fVal, err)
+				}
+			case MetadataValueTypeString:
+				sVal, err := m.GetString(k)
+				if sVal == nil || err != nil {
+					t.Errorf("Expected no error for Metadata GetString, got (%v),(%v)", sVal, err)
+				}
+			case MetadataValueTypeBool:
+				bVal, err := m.GetBool(k)
+				if bVal == nil || err != nil {
+					t.Errorf("Expected no error for Metadata GetBool, got (%v),(%v)", bVal, err)
+				}
+			case MetadataValueTypeObject:
+				oVal, err := m.GetObject(k)
+				if oVal == nil || err != nil {
+					t.Errorf("Expected no error for Metadata GetObject, got (%v),(%v)", oVal, err)
+				}
+			}
+
+			for typ, failTest := range expectFailFuncs {
+				if typ == v.Type {
+					// Skip, tested earlier for success
+					continue
+				}
+				failTest(k)
+			}
+		}
+
+	})
+
+	t.Run("HasType functions, fail with missing keys as expected", func(t *testing.T) {
+		m := Metadata{}
+
+		iVal, err := m.GetInt("notakey")
+		if iVal != nil || err != ErrMetadataNonexistantKey {
+			t.Errorf("Expected nonexistant key error for Metadata GetInt, got (%v),(%v)", iVal, err)
+		}
+		fVal, err := m.GetFloat("notakey")
+		if fVal != nil || err != ErrMetadataNonexistantKey {
+			t.Errorf("Expected nonexistant key error for Metadata GetFloat, got (%v),(%v)", fVal, err)
+		}
+		sVal, err := m.GetString("notakey")
+		if sVal != nil || err != ErrMetadataNonexistantKey {
+			t.Errorf("Expected nonexistant key error for Metadata GetString, got (%v),(%v)", sVal, err)
+		}
+		bVal, err := m.GetBool("notakey")
+		if bVal != nil || err != ErrMetadataNonexistantKey {
+			t.Errorf("Expected nonexistant key error for Metadata GetBool, got (%v),(%v)", bVal, err)
+		}
+		oVal, err := m.GetObject("notakey")
+		if oVal != nil || err != ErrMetadataNonexistantKey {
+			t.Errorf("Expected nonexistant key error for Metadata GetObject, got (%v),(%v)", oVal, err)
 		}
 	})
 }
@@ -172,10 +281,10 @@ func TestMetadataValue(t *testing.T) {
 		for _, j := range JSONs {
 			mdv := &MetadataValue{}
 			if err := json.Unmarshal([]byte(j), &mdv); err != nil {
-				t.Error(err)
+				t.Errorf("Failed to Unmarshal (%s) : %s", j, err.Error())
 			}
 			if err := mdv.Validate(nil); err != nil {
-				t.Error(err)
+				t.Errorf("Failed to Validate (%v) : %s", mdv, err.Error())
 			}
 		}
 	})

--- a/types_test.go
+++ b/types_test.go
@@ -98,12 +98,12 @@ func TestMetadata(t *testing.T) {
 
 	t.Run("Expected Metadata is considered valid", func(t *testing.T) {
 		mds := []Metadata{
-			Metadata{
+			{
 				"abra":       1,
 				"bulbasaur":  "TWO",
 				"charmander": false,
 			},
-			Metadata{
+			{
 				"abra":       1,
 				"bulbasaur":  "TWO",
 				"charmander": false,
@@ -113,7 +113,7 @@ func TestMetadata(t *testing.T) {
 					"charmander": false,
 				},
 			},
-			Metadata{
+			{
 				"abra":       1,
 				"bulbasaur":  "TWO",
 				"charmander": false,
@@ -134,23 +134,23 @@ func TestMetadata(t *testing.T) {
 
 	t.Run("Expected Metadata is considered invalid", func(t *testing.T) {
 		mds := []Metadata{
-			Metadata{
+			{
 				"$$$BADLABEL$$": 1,
 			},
-			Metadata{
+			{
 				"bad-value-type": json.Encoder{},
 			},
-			Metadata{
+			{
 				"nested-value-err": Metadata{
 					"$$$BADLABEL$$": 1,
 				},
 			},
-			Metadata{
+			{
 				"nested-value-err": map[string]interface{}{
 					"$$$BADLABEL$$": 1,
 				},
 			},
-			Metadata{
+			{
 				"json-too-big": makeBigString(MetadataMaxSize),
 			},
 		}


### PR DESCRIPTION
This adds a type to store metadata.
This will be used for provision operations and resources initially.

Relates manifoldco/engineering#5801