### PR TITLE
Simpler CompositeID, removing the InternalID in favor of existing ID

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -108,7 +108,7 @@ func (e *Event) Version() int { return e.StructVersion }
 func (e *Event) Type() idtype.Type { return idtype.ActivityEvent }
 
 // Validate returns whether or not the given Event is valid
-func (e *Event) Validate(v interface{}) error {
+func (e *Event) Validate(v strfmt.Registry) error {
 	if err := e.ID.Validate(v); err != nil {
 		return err
 	}

--- a/flexid.go
+++ b/flexid.go
@@ -279,10 +279,12 @@ func (id FlexID) AsManifoldID() (*ID, error) {
 // Ensure interface adherence
 var (
 	_ runtime.Validatable      = Domain("")
+	_ fmt.Stringer             = Domain("")
+	_ runtime.Validatable      = Class("")
+	_ fmt.Stringer             = Class("")
 	_ runtime.Validatable      = ExternalID("")
+	_ fmt.Stringer             = ExternalID("")
 	_ CompositeID              = &FlexID{}
-	_ fmt.Stringer             = &FlexID{}
-	_ runtime.Validatable      = &FlexID{}
 	_ encoding.TextMarshaler   = &FlexID{}
 	_ encoding.TextUnmarshaler = &FlexID{}
 	_ json.Marshaler           = &FlexID{}

--- a/flexid.go
+++ b/flexid.go
@@ -31,22 +31,22 @@ var (
 	errNilValue = NewError(errors.InternalServerError,
 		"Invalid CompositeID, cannot unmarshal to nil ID")
 	errInvalidParts = NewError(errors.BadRequestError,
-		"Invalid CompositeID, expected 3 parts, Domain, Type, and ID")
+		"Invalid CompositeID, expected 3 parts, Domain, Class, and ID")
 	errInvalidDomain = NewError(errors.BadRequestError,
 		"Invalid CompositeID, expected a valid Domain in the first segment")
-	errInvalidType = NewError(errors.BadRequestError,
-		"Invalid CompositeID, expected a valid Type in the last segment")
+	errInvalidClass = NewError(errors.BadRequestError,
+		"Invalid CompositeID, expected a valid Class in the last segment")
 	errInvalidID = NewError(errors.BadRequestError,
 		"Invalid CompositeID, expected a valid ID in the last segment")
 
-	// ErrNotAInternalID is an error returned when a CompositeID is expected to
-	//  be a InternalID, but is not.
-	ErrNotAInternalID = NewError(errors.BadRequestError,
-		"Malformed InternalID, expected form `manifold.co\\TYPE\\MANIFOLDID`")
-	// ErrInternalIDTypeMismatch is an error returned when a CompositeID is expected to
-	//  be a InternalID, but is not because the type does not match.
-	ErrInternalIDTypeMismatch = NewError(errors.BadRequestError,
-		"Invalid InternalID, expected TYPE from `manifold.co\\TYPE\\ID` to match ID Type")
+	// ErrNotAManifoldID is an error returned when a CompositeID is expected to
+	//  be a Manifold ID, but is not.
+	ErrNotAManifoldID = NewError(errors.BadRequestError,
+		"Malformed Manifold ID, expected form `manifold.co\\CLASS\\MANIFOLDID`")
+	// ErrManifoldIDTypeMismatch is an error returned when a CompositeID is expected to
+	//  be a Manifold ID, but is not because the type does not match.
+	ErrManifoldIDTypeMismatch = NewError(errors.BadRequestError,
+		"Invalid Manifold ID, expected CLASS from `manifold.co\\CLASS\\ID` to match ID Type")
 )
 
 // Domain is a string that can be Validated based on Regex to expect a string
@@ -74,6 +74,29 @@ func (d Domain) SubDomain() string {
 	return ""
 }
 
+// String implements the Stringer interface to easily convert a Domain to a String
+func (d Domain) String() string {
+	return string(d)
+}
+
+// Class is a Manifold Label that is used to represent the class of an ID
+type Class Label
+
+// Validate implements the runtime Validatable interface
+func (c Class) Validate(r strfmt.Registry) error {
+	return c.Label().Validate(r)
+}
+
+// String implements the Stringer interface to easily convert a Class to a String
+func (c Class) String() string {
+	return string(c)
+}
+
+// Label implements the Stringer interface to easily convert a Class to a Manifold Label
+func (c Class) Label() Label {
+	return Label(c)
+}
+
 // ExternalID is a string that can be Validated based on Regex to expect a string
 //  representative of an ExternalID
 type ExternalID string
@@ -87,120 +110,43 @@ func (eid ExternalID) Validate(_ strfmt.Registry) error {
 	return errInvalidID
 }
 
+// String implements the Stringer interface to easily convert a ExternalID to a String
+func (id ExternalID) String() string {
+	return string(id)
+}
+
 // CompositeID is an ID that also includes the domain, and type of the identifier.
-//  Composed as: DOMAIN / TYPE / ID
+//  Composed as: DOMAIN / CLASS / ID
 //  Example: manifold.co/user/2003btphq7z6dzvjut370jkvkdgcp
 //  Has `manifold.co` as the domain, a type of `user`, followed by the Manifold ID.
 type CompositeID interface {
+	fmt.Stringer
+	runtime.Validatable
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+
 	// Domain returns the Domain ( first ) portion of the CompositeID
 	Domain() Domain
-	// Type returns the Type ( second ) portion of the CompositeID
-	Type() Label
+	// Class returns the Class ( second ) portion of the CompositeID
+	Class() Class
 	// ID returns the ID ( third ) portion of the CompositeID
 	ID() ExternalID
 	// AsFlexID allows for easy conversion of all CompositeIDs to the most forgiving struct
 	AsFlexID() *FlexID
-	// Stringer interface for easy translation to string
-	String() string
-	// Validate allows for OpenAPI validation of our structs so we can use them in
-	//  OpenAPI schemas
-	Validate(strfmt.Registry) error
-	// MarshalText allows CompositeIDs to be easily converted to text
-	MarshalText() ([]byte, error)
-	// UnmarshalText allows CompositeIDs to be easily parsed from text
-	UnmarshalText(b []byte) error
-	// MarshalText allows CompositeIDs to be easily converted to text
-	MarshalJSON() ([]byte, error)
-	// UnmarshalText allows CompositeIDs to be easily parsed from text
-	UnmarshalJSON(b []byte) error
 }
 
-// InternalID is an implementation of CompositeID that wraps the existing Manifold ID type.
-//  This allow us to quickly convert existing IDs to the CompositeID format
-type InternalID ID
-
-// Domain returns the domain portion as a string
-func (m InternalID) Domain() Domain {
-	return ManifoldDomain
-}
-
-// Type returns the type portion as string
-func (m InternalID) Type() Label {
-	return Label(ID(m).Type().Name())
-}
-
-// ID returns the ID portion as a string
-func (m InternalID) ID() ExternalID {
-	return ExternalID(ID(m).String())
-}
-
-// AsFlexID returns the ID as the FlexID type as required by the CompositeID interface
-func (m InternalID) AsFlexID() *FlexID {
-	return &FlexID{string(m.Domain()), string(m.Type()), string(m.ID())}
-}
-
-// String implements the Stringer interface for go
-func (m InternalID) String() string {
-	return fmt.Sprintf("%s%s%s%s%s", m.Domain(), pathSeperator, m.Type(),
-		pathSeperator, m.ID())
-}
-
-// Validate implements the Validate interface for goswagger
-func (m InternalID) Validate(v strfmt.Registry) error {
-	return ID(m).Validate(v)
-}
-
-// MarshalText implements the encoding.TextMarshaler interface
-func (m InternalID) MarshalText() ([]byte, error) {
-	return []byte(m.String()), nil
-}
-
-// UnmarshalText implements the encoding.TextUnmarshaler interface
-func (m *InternalID) UnmarshalText(b []byte) error {
-	if m == nil {
-		return errNilValue
+// NewFlexID constructs a FlexID from the provided Domain, Class, and ID parts
+func NewFlexID(d Domain, c Class, id ExternalID) (*FlexID, error) {
+	out := FlexID{d.String(), c.String(), id.String()}
+	if err := out.Validate(nil); err != nil {
+		return nil, err
 	}
-	id := FlexID{}
-	if err := id.UnmarshalText(b); err != nil {
-		return err
-	}
-	mid, err := id.AsInternalID()
-	if err != nil {
-		return err
-	}
-	copy(m[:], mid[:])
-	return err
+	return &out, nil
 }
 
-// UnmarshalJSON implements the encoding/json.Unmarshaler interface
-func (m *InternalID) UnmarshalJSON(b []byte) error {
-	if m == nil {
-		return errNilValue
-	}
-	id := &FlexID{}
-	if err := id.UnmarshalJSON(b); err != nil {
-		return err
-	}
-	mid, err := id.AsInternalID()
-	if err != nil {
-		return err
-	}
-	copy(m[:], mid[:])
-	return err
-}
-
-// MarshalJSON implements the encoding/json.Marshaler interface
-func (m InternalID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(m.String())
-}
-
-// AsID casts the InternalID pointer to a ID pointer for convenience
-func (m *InternalID) AsID() *ID {
-	if m == nil {
-		return nil
-	}
-	id := ID(*m)
-	return &id
+// FlexIDFromID takes a Manifold ID and converts it to a FlexID for storage
+func FlexIDFromID(id ID) *FlexID {
+	return &FlexID{id.Domain().String(), id.Class().String(), id.ID().String()}
 }
 
 // FlexID is an implementation of CompositeID that is designed to store internal
@@ -213,9 +159,9 @@ func (id FlexID) Domain() Domain {
 	return Domain(id[0])
 }
 
-// Type returns the type portion as string
-func (id FlexID) Type() Label {
-	return Label(id[1])
+// Class returns the type portion as string
+func (id FlexID) Class() Class {
+	return Class(id[1])
 }
 
 // ID returns the ID portion as a string
@@ -230,7 +176,7 @@ func (id FlexID) AsFlexID() *FlexID {
 
 // String implements the Stringer interface for go
 func (id FlexID) String() string {
-	return fmt.Sprintf("%s%s%s%s%s", id.Domain(), pathSeperator, id.Type(),
+	return fmt.Sprintf("%s%s%s%s%s", id.Domain(), pathSeperator, id.Class(),
 		pathSeperator, id.ID())
 }
 
@@ -240,8 +186,8 @@ func (id FlexID) Validate(v strfmt.Registry) error {
 	if err := id.Domain().Validate(v); err != nil {
 		return err
 	}
-	if id.Type().Validate(v) != nil {
-		return errInvalidType
+	if id.Class().Validate(v) != nil {
+		return errInvalidClass
 	}
 	if err := id.ID().Validate(v); err != nil {
 		return err
@@ -261,11 +207,19 @@ func (id *FlexID) UnmarshalText(b []byte) error {
 		return errNilValue
 	}
 	parts := strings.Split(string(b), pathSeperator)
-	if len(parts) != 3 {
+	switch len(parts) {
+	case 1:
+		// Try to parse as a Manifold ID
+		mid := &ID{}
+		if err := mid.UnmarshalText(b); err != nil {
+			return errInvalidParts
+		}
+		copy(id[:], (*mid.AsFlexID())[:])
+	case 3:
+		copy(id[:], parts)
+	default:
 		return errInvalidParts
 	}
-
-	copy(id[:], parts)
 
 	if err := id.Validate(nil); err != nil {
 		return err
@@ -279,6 +233,8 @@ func (id *FlexID) UnmarshalJSON(b []byte) error {
 	if id == nil {
 		return errNilValue
 	}
+	// First to attempt to unmarshal as array, though this is undesired as a storage
+	//  format it's easy to support for translation
 	var parts [3]string
 	if err := json.Unmarshal(b, &parts); err != nil {
 		// Attempt to unmarshal as string
@@ -286,6 +242,7 @@ func (id *FlexID) UnmarshalJSON(b []byte) error {
 		if err := json.Unmarshal(b, &s); err != nil {
 			return errInvalidParts
 		}
+		// Leverage the text unmarshalling now we have the string
 		return id.UnmarshalText([]byte(s))
 	}
 
@@ -303,34 +260,26 @@ func (id FlexID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id.String())
 }
 
-// AsInternalID validates that the FlexID adheres with the requirements of a InternalID
+// AsManifoldID validates that the FlexID adheres with the requirements of a ManifoldID
 //  and attempts to cast it to one
-func (id FlexID) AsInternalID() (*InternalID, error) {
+func (id FlexID) AsManifoldID() (*ID, error) {
 	if id.Domain() != ManifoldDomain {
-		return nil, ErrNotAInternalID
+		return nil, ErrNotAManifoldID
 	}
-	mid, err := DecodeIDFromString(string(id.ID()))
+	mid, err := DecodeIDFromString(id.ID().String())
 	if err != nil {
-		return nil, ErrNotAInternalID
+		return nil, ErrNotAManifoldID
 	}
-	if mid.Type().Name() != string(id.Type()) {
-		return nil, ErrInternalIDTypeMismatch
+	if mid.Type().Name() != id.Class().String() {
+		return nil, ErrManifoldIDTypeMismatch
 	}
-	out := InternalID(mid)
-	return &out, nil
+	return &mid, nil
 }
 
 // Ensure interface adherence
 var (
 	_ runtime.Validatable      = Domain("")
 	_ runtime.Validatable      = ExternalID("")
-	_ CompositeID              = &InternalID{}
-	_ fmt.Stringer             = &InternalID{}
-	_ runtime.Validatable      = &InternalID{}
-	_ encoding.TextMarshaler   = &InternalID{}
-	_ encoding.TextUnmarshaler = &InternalID{}
-	_ json.Marshaler           = &InternalID{}
-	_ json.Unmarshaler         = &InternalID{}
 	_ CompositeID              = &FlexID{}
 	_ fmt.Stringer             = &FlexID{}
 	_ runtime.Validatable      = &FlexID{}
@@ -338,4 +287,5 @@ var (
 	_ encoding.TextUnmarshaler = &FlexID{}
 	_ json.Marshaler           = &FlexID{}
 	_ json.Unmarshaler         = &FlexID{}
+	_ CompositeID              = &ID{}
 )

--- a/flexid.go
+++ b/flexid.go
@@ -29,21 +29,21 @@ var (
 	idRegex = regexp.MustCompile(`^\{?[a-zA-Z0-9+/-_]{1,256}={0,2}\}?$`)
 
 	errNilValue = NewError(errors.InternalServerError,
-		"Invalid CompositeID, cannot unmarshal to nil ID")
+		"Invalid Identifier, cannot unmarshal to nil ID")
 	errInvalidParts = NewError(errors.BadRequestError,
-		"Invalid CompositeID, expected 3 parts, Domain, Class, and ID")
+		"Invalid Identifier, expected 3 parts, Domain, Class, and ID")
 	errInvalidDomain = NewError(errors.BadRequestError,
-		"Invalid CompositeID, expected a valid Domain in the first segment")
+		"Invalid Identifier, expected a valid Domain in the first segment")
 	errInvalidClass = NewError(errors.BadRequestError,
-		"Invalid CompositeID, expected a valid Class in the last segment")
+		"Invalid Identifier, expected a valid Class in the last segment")
 	errInvalidID = NewError(errors.BadRequestError,
-		"Invalid CompositeID, expected a valid ID in the last segment")
+		"Invalid Identifier, expected a valid ID in the last segment")
 
-	// ErrNotAManifoldID is an error returned when a CompositeID is expected to
+	// ErrNotAManifoldID is an error returned when a Identifier is expected to
 	//  be a Manifold ID, but is not.
 	ErrNotAManifoldID = NewError(errors.BadRequestError,
 		"Malformed Manifold ID, expected form `manifold.co\\CLASS\\MANIFOLDID`")
-	// ErrManifoldIDTypeMismatch is an error returned when a CompositeID is expected to
+	// ErrManifoldIDTypeMismatch is an error returned when a Identifier is expected to
 	//  be a Manifold ID, but is not because the type does not match.
 	ErrManifoldIDTypeMismatch = NewError(errors.BadRequestError,
 		"Invalid Manifold ID, expected CLASS from `manifold.co\\CLASS\\ID` to match ID Type")
@@ -115,21 +115,21 @@ func (eid ExternalID) String() string {
 	return string(eid)
 }
 
-// CompositeID is an ID that also includes the domain, and type of the identifier.
+// Identifier is an ID that also includes the domain, and type of the identifier.
 //  Composed as: DOMAIN / CLASS / ID
 //  Example: manifold.co/user/2003btphq7z6dzvjut370jkvkdgcp
 //  Has `manifold.co` as the domain, a type of `user`, followed by the Manifold ID.
-type CompositeID interface {
+type Identifier interface {
 	fmt.Stringer
 	runtime.Validatable
 
-	// Domain returns the Domain ( first ) portion of the CompositeID
+	// Domain returns the Domain ( first ) portion of the Identifier
 	Domain() Domain
-	// Class returns the Class ( second ) portion of the CompositeID
+	// Class returns the Class ( second ) portion of the Identifier
 	Class() Class
-	// ID returns the ID ( third ) portion of the CompositeID
+	// ID returns the ID ( third ) portion of the Identifier
 	ID() ExternalID
-	// AsFlexID allows for easy conversion of all CompositeIDs to the most forgiving struct
+	// AsFlexID allows for easy conversion of all Identifiers to the most forgiving struct
 	AsFlexID() *FlexID
 }
 
@@ -147,7 +147,7 @@ func FlexIDFromID(id ID) *FlexID {
 	return &FlexID{id.Domain().String(), id.Class().String(), id.ID().String()}
 }
 
-// FlexID is an implementation of CompositeID that is designed to store internal
+// FlexID is an implementation of Identifier that is designed to store internal
 //  and external IDs it could still store InternalIDs but the InternalID type is
 //  preferred as it is directly translatable to a `ID`
 type FlexID [3]string
@@ -167,7 +167,7 @@ func (id FlexID) ID() ExternalID {
 	return ExternalID(id[2])
 }
 
-// AsFlexID returns the ID as the FlexID type as required by the CompositeID interface
+// AsFlexID returns the ID as the FlexID type as required by the Identifier interface
 func (id FlexID) AsFlexID() *FlexID {
 	return &id
 }
@@ -282,10 +282,10 @@ var (
 	_ fmt.Stringer             = Class("")
 	_ runtime.Validatable      = ExternalID("")
 	_ fmt.Stringer             = ExternalID("")
-	_ CompositeID              = &FlexID{}
+	_ Identifier               = &FlexID{}
 	_ encoding.TextMarshaler   = &FlexID{}
 	_ encoding.TextUnmarshaler = &FlexID{}
 	_ json.Marshaler           = &FlexID{}
 	_ json.Unmarshaler         = &FlexID{}
-	_ CompositeID              = &ID{}
+	_ Identifier               = &ID{}
 )

--- a/flexid.go
+++ b/flexid.go
@@ -122,8 +122,6 @@ func (id ExternalID) String() string {
 type CompositeID interface {
 	fmt.Stringer
 	runtime.Validatable
-	encoding.TextMarshaler
-	encoding.TextUnmarshaler
 
 	// Domain returns the Domain ( first ) portion of the CompositeID
 	Domain() Domain

--- a/flexid.go
+++ b/flexid.go
@@ -111,8 +111,8 @@ func (eid ExternalID) Validate(_ strfmt.Registry) error {
 }
 
 // String implements the Stringer interface to easily convert a ExternalID to a String
-func (id ExternalID) String() string {
-	return string(id)
+func (eid ExternalID) String() string {
+	return string(eid)
 }
 
 // CompositeID is an ID that also includes the domain, and type of the identifier.

--- a/id.go
+++ b/id.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"strconv"
 
+	"github.com/go-openapi/strfmt"
+
 	"github.com/dchest/blake2b"
 
 	"github.com/manifoldco/go-base32"
@@ -185,7 +187,7 @@ func decodeFromByte(raw []byte) ([]byte, error) {
 // Validate implements the Validate interface for goswagger.
 // We know that if the value has successfully parsed, it is valid, so no action
 // is required.
-func (id ID) Validate(_ interface{}) error {
+func (id ID) Validate(_ strfmt.Registry) error {
 	return nil
 }
 
@@ -194,8 +196,22 @@ func (id ID) IsEmpty() bool {
 	return id == emptyID
 }
 
-// AsComposite converts the ID to a CompositeID
-func (id ID) AsComposite() *InternalID {
-	mid := InternalID(id)
-	return &mid
+// Domain returns the domain portion as a string
+func (id ID) Domain() Domain {
+	return ManifoldDomain
+}
+
+// Class returns the type of the ID as a Class
+func (id ID) Class() Class {
+	return Class(id.Type().Name())
+}
+
+// ID returns the Manifold ID as an ExternalID string
+func (id ID) ID() ExternalID {
+	return ExternalID(id.String())
+}
+
+// AsFlexID converts the ID to a FlexID
+func (id ID) AsFlexID() *FlexID {
+	return FlexIDFromID(id)
 }


### PR DESCRIPTION
TLDR; Less Code, More functionality

Got it down to just ID and FlexID with CompositeID being the shared interface
Added support for UnMarshalling a FlexID from a Manifold ID to make database conversions easier
Marshalling is no longer an expectation of the CompositeID interfaces
We will use FlexID when we want to store the FlexID format, and ID when we want to store the Manifold ID format ( internal IDs only )

Relates manifoldco/engineering#6573