### PR TITLE
Adds format validation for credential keys and body

### DIFF
--- a/formats.go
+++ b/formats.go
@@ -15,6 +15,8 @@ var (
 	featureValueLabelRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-_\.]{1,128}$`)
 	annotationKeyRegex     = regexp.MustCompile(`^(?:[a-z0-9][a-z0-9-\.\/]{0,62}[a-z0-9]|[a-z0-9])$`)
 	annotationValueRegex   = regexp.MustCompile(`^(?:[a-zA-Z0-9][a-zA-Z0-9-\.\/]{0,252}[a-zA-Z0-9]|[a-zA-Z0-9])$`)
+	credentialKeyRegex     = regexp.MustCompile(`^[A-Z][A-Z0-9_]{0,999}$`)
+	maxCredentialBodySize  = 1024
 )
 
 var (
@@ -29,6 +31,10 @@ var (
 		"Invalid annotation key provided")
 	errInvalidAnnotationValue = NewError(errors.BadRequestError,
 		"Invalid annotation value provided")
+	errInvalidCredentialKey = NewError(errors.BadRequestError,
+		"Invalid credential key provided")
+	errInvalidCredentialValue = NewError(errors.BadRequestError,
+		"Invalid credential body provided")
 )
 
 // Label represents any object's label field
@@ -113,4 +119,28 @@ func (val AnnotationValue) Validate(_ interface{}) error {
 	}
 
 	return errInvalidAnnotationValue
+}
+
+// CredentialKey represents a key for a secret credential associated with a resource
+type CredentialKey string
+
+// Validate ensures the credential key is valid
+func (key CredentialKey) Validate(_ interface{}) error {
+	if credentialKeyRegex.Match([]byte(key)) {
+		return nil
+	}
+
+	return errInvalidCredentialKey
+}
+
+// CredentialKey represents a key for a secret credential associated with a resource
+type CredentialBody string
+
+// Validate ensures the credential key is valid
+func (body CredentialBody) Validate(_ interface{}) error {
+	if len(body) > maxCredentialBodySize {
+		return errInvalidCredentialValue
+	}
+
+	return nil
 }

--- a/formats.go
+++ b/formats.go
@@ -16,7 +16,7 @@ var (
 	annotationKeyRegex     = regexp.MustCompile(`^(?:[a-z0-9][a-z0-9-\.\/]{0,62}[a-z0-9]|[a-z0-9])$`)
 	annotationValueRegex   = regexp.MustCompile(`^(?:[a-zA-Z0-9][a-zA-Z0-9-\.\/]{0,252}[a-zA-Z0-9]|[a-zA-Z0-9])$`)
 	credentialKeyRegex     = regexp.MustCompile(`^[A-Z][A-Z0-9_]{0,999}$`)
-	maxCredentialBodySize  = 1024
+	maxCredentialBodySize  = 32 * 1024
 )
 
 var (
@@ -133,10 +133,10 @@ func (key CredentialKey) Validate(_ interface{}) error {
 	return errInvalidCredentialKey
 }
 
-// CredentialKey represents a key for a secret credential associated with a resource
+// CredentialBody represents the body for a secret credential associated with a resource
 type CredentialBody string
 
-// Validate ensures the credential key is valid
+// Validate ensures the credential body is valid
 func (body CredentialBody) Validate(_ interface{}) error {
 	if len(body) > maxCredentialBodySize {
 		return errInvalidCredentialValue

--- a/formats_test.go
+++ b/formats_test.go
@@ -172,3 +172,44 @@ func TestAnnotationValue(t *testing.T) {
 		}
 	})
 }
+
+func TestCredentialKey(t *testing.T) {
+	t.Run("errors on invalid credential key", func(t *testing.T) {
+		l := CredentialKey("abc")
+		err := l.Validate(nil)
+		if err == nil {
+			t.Error("Expected an error")
+		}
+	})
+
+	t.Run("does not error on valid credential key", func(t *testing.T) {
+		l := CredentialKey("ABC")
+		err := l.Validate(nil)
+		if err != nil {
+			t.Errorf("Unexpected Error: %s", err)
+		}
+	})
+}
+
+func TestCredentialBody(t *testing.T) {
+	t.Run("errors on invalid credential body", func(t *testing.T) {
+		longString := ""
+
+		for len(longString) <= maxCredentialBodySize {
+			longString += "a"
+		}
+		l := CredentialBody(longString)
+		err := l.Validate(nil)
+		if err == nil {
+			t.Error("Expected an error")
+		}
+	})
+
+	t.Run("does not error on valid credential value", func(t *testing.T) {
+		l := CredentialBody("hey, that's not 1024 bytes long!")
+		err := l.Validate(nil)
+		if err != nil {
+			t.Errorf("Unexpected Error: %s", err)
+		}
+	})
+}


### PR DESCRIPTION
When sending requests to put credentials inside the partners API, we want to make sure those credentials are within the system limits for environment variables. These changes add a basic check for credential keys and bodies, more checks will be needed on marketplace's side.