### PR TITLE
Expanded Identifier Interface

### DIFF
--- a/flexid.go
+++ b/flexid.go
@@ -131,8 +131,13 @@ type Identifier interface {
 	ID() ExternalID
 	// AsFlexID allows for easy conversion of all Identifiers to the most forgiving struct
 	AsFlexID() *FlexID
+	// AsManifoldID allows for conversion of all Identifiers to a Manifold identifier if
+	//  compatible, otherwise an error is returned and the ID is nil
+	AsManifoldID() (*ID, error)
 	// IsEmpty returns true if the ID is considered empty
 	IsEmpty() bool
+	// Equals checks the equality of this Identifier against another
+	Equals(Identifier) bool
 }
 
 // NewFlexID constructs a FlexID from the provided Domain, Class, and ID parts
@@ -293,6 +298,16 @@ func (id FlexID) IsEmpty() bool {
 		}
 	}
 	return false
+}
+
+// Equals is implemented to allow for easy comparison of FlexIDs to IDs using the
+//  Identifier interface
+func (id FlexID) Equals(oid Identifier) bool {
+	if oid == nil {
+		return false
+	}
+	fid := oid.AsFlexID()
+	return fid != nil && *fid == id
 }
 
 // Ensure interface adherence

--- a/flexid_test.go
+++ b/flexid_test.go
@@ -26,6 +26,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	_, _ = validID.AsManifoldID()
 	// Call AsFlexID for coverage on both types :D
 	validFlexID = validID.AsFlexID().AsFlexID()
 
@@ -488,6 +489,112 @@ func TestFlexID_IsEmpty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.id.IsEmpty(); got != tt.want {
 				t.Errorf("FlexID.IsEmpty() = %v, want %v, value: %v", got, tt.want, tt.id)
+			}
+		})
+	}
+}
+
+func TestFlexID_Equals(t *testing.T) {
+	tests := []struct {
+		name string
+		id   FlexID
+		oid  Identifier
+		want bool
+	}{
+		{
+			name: "FlexID equals FlexID - ok",
+			id:   FlexID{"bus.com", "driver", "Benny"},
+			oid:  FlexID{"bus.com", "driver", "Benny"},
+			want: true,
+		},
+		{
+			name: "FlexID equals ID - ok",
+			id:   *validFlexID,
+			oid:  validID,
+			want: true,
+		},
+		{
+			name: "Empty FlexID equals Empty FlexID - ok",
+			id:   FlexID{},
+			oid:  FlexID{},
+			want: true,
+		},
+		{
+			name: "Empty FlexID equals Empty ID - not ok",
+			id:   FlexID{},
+			oid:  ID{},
+			want: false,
+		},
+		{
+			name: "FlexID equals Nil - not ok",
+			id:   *validFlexID,
+			oid:  nil,
+			want: false,
+		},
+		{
+			name: "FlexID equals different FlexID - not ok",
+			id:   FlexID{"bus.com", "driver", "Benny"},
+			oid:  FlexID{"bus.com", "driver", "Bob"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id.Equals(tt.oid); got != tt.want {
+				t.Errorf("FlexID.Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestID_Equals(t *testing.T) {
+	tests := []struct {
+		name string
+		id   ID
+		oid  Identifier
+		want bool
+	}{
+		{
+			name: "ID equals ID - ok",
+			id:   validID,
+			oid:  validID,
+			want: true,
+		},
+		{
+			name: "ID equals FlexID - ok",
+			id:   validID,
+			oid:  *validFlexID,
+			want: true,
+		},
+		{
+			name: "Empty ID equals Empty  ID - ok",
+			id:   ID{},
+			oid:  ID{},
+			want: true,
+		},
+		{
+			name: "Empty ID equals Empty FlexID - not ok",
+			id:   ID{},
+			oid:  FlexID{},
+			want: false,
+		},
+		{
+			name: "ID equals Nil - not ok",
+			id:   validID,
+			oid:  nil,
+			want: false,
+		},
+		{
+			name: "ID equals different ID - not ok",
+			id:   validID,
+			oid:  ID{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id.Equals(tt.oid); got != tt.want {
+				t.Errorf("FlexID.Equals() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/id.go
+++ b/id.go
@@ -215,3 +215,19 @@ func (id ID) ID() ExternalID {
 func (id ID) AsFlexID() *FlexID {
 	return FlexIDFromID(id)
 }
+
+// AsManifoldID returns the ID as itself without error, implemented to adhere
+//  to the Identifier interface
+func (id ID) AsManifoldID() (*ID, error) {
+	return &id, nil
+}
+
+// Equals is implemented to allow for easy comparison of FlexIDs to IDs using the
+//  Identifier interface
+func (id ID) Equals(oid Identifier) bool {
+	if oid == nil {
+		return false
+	}
+	mid, _ := oid.AsManifoldID()
+	return mid != nil && *mid == id
+}


### PR DESCRIPTION
This expands the identifier interface to make it easier to work with FlexIDs and IDs side by side
The plan is to use this change to make refactoring the Principal Interface to run off of Identifiers
 instead of the struct type ID, to allow us to use FlexIDs more interchangably within Principals
 in marketplace.

Relates manifoldco/engineering#6810