### PR TITLE
Identity: handle self get 400 error.

### DIFF
--- a/specs/identity.yaml
+++ b/specs/identity.yaml
@@ -230,6 +230,9 @@ paths:
           description: A user object.
           schema:
             $ref: '#/definitions/User'
+        400:
+          description: Bad request
+          schema: { $ref: '#/definitions/Error' }
         401:
           description: Unknown token, or token not owned the the requester
           schema:

--- a/zz_oag_generated_identity.go
+++ b/zz_oag_generated_identity.go
@@ -668,7 +668,7 @@ func (c *SelfClient) Get(ctx context.Context) (*User, error) {
 	var resp User
 	_, err = c.backend.Do(ctx, req, &resp, func(code int) error {
 		switch code {
-		case 401, 500:
+		case 400, 401, 500:
 			return &Error{}
 		default:
 			return nil


### PR DESCRIPTION
This was pushed up in the marketplace specs, but not ported to
go-manifold.