### PR TITLE
Add method MustNewID

### DIFF
--- a/id.go
+++ b/id.go
@@ -98,6 +98,16 @@ func NewID(t idtype.Type) (ID, error) {
 	return id, nil
 }
 
+// MustNewID returns a new ID for a Mutable idtype using only the Type
+// It panics if NewID returns an error
+func MustNewID(t idtype.Type) ID {
+	id, err := NewID(t)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // NewImmutableID returns a new signed ID for an immutable object.
 //
 // sig should be a registry.Signature type


### PR DESCRIPTION
MustNewID is a helper that panic if NewID returns an error. In this case is either a programmer error or `rand` failed to read.