### PR TITLE
Quick fix to have the categories table work with idtypes

### DIFF
--- a/idtype/idtype.go
+++ b/idtype/idtype.go
@@ -168,15 +168,20 @@ func getDefn(t Type) definition {
 // of the name. If omitted, the name will have an s appended to generate its plural version.
 //
 // Register panics if it is called twice with the same Type.
-func Register(typ Type, mutable bool, name string, options ...string) {
+func Register(typ Type, mutable bool, name string, options ...interface{}) {
 	var plural *string
 
 	if _, ok := definitions[typ]; ok {
 		panic("Type already registered: " + string(typ))
 	}
 
-	if len(options) >= 1 {
-		plural = &options[0]
+	if len(options) > 0 {
+		for _, item := range options {
+			if val, ok := item.(PluralizedString); ok {
+				stringVal := string(val)
+				plural = &stringVal
+			}
+		}
 	}
 
 	definitions[typ] = definition{
@@ -184,6 +189,14 @@ func Register(typ Type, mutable bool, name string, options ...string) {
 		name:    name,
 		plural:  plural,
 	}
+}
+
+// PluralizedString is the pluralized version of a definition name
+type PluralizedString string
+
+// WithPlural is an utility function to pass the plural name option to the Register function
+func WithPlural(name string) PluralizedString {
+	return PluralizedString(name)
 }
 
 // TypeFromString will return the type from a string interpretation of the type.
@@ -223,7 +236,7 @@ func init() {
 	Register(Product, true, "product")
 	Register(Plan, true, "plan")
 	Register(Region, true, "region")
-	Register(Category, true, "category", "categories")
+	Register(Category, true, "category", WithPlural("categories"))
 
 	Register(Operation, true, "operation")
 	Register(Callback, true, "callback")

--- a/idtype/idtype.go
+++ b/idtype/idtype.go
@@ -117,7 +117,7 @@ func (t Type) Collection() string {
 	case strings.HasSuffix(defn.name, "access"):
 		return defn.name
 	default:
-		return fmt.Sprintf("%ss", defn.name)
+		return t.Plural()
 	}
 }
 
@@ -125,6 +125,17 @@ func (t Type) Collection() string {
 func (t Type) Name() string {
 	defn := getDefn(t)
 	return defn.name
+}
+
+// Plural returns the plural name of an instance of this type
+func (t Type) Plural() string {
+	defn := getDefn(t)
+
+	if defn.plural != nil {
+		return *defn.plural
+	}
+
+	return fmt.Sprintf("%ss", defn.name)
 }
 
 // String returns the string representation of the primitive type
@@ -153,12 +164,26 @@ func getDefn(t Type) definition {
 // Any types used *must* be registered. Ideally, call this from your package's
 // init function.
 //
+// The third argument of register are the options. It currently only support one option, setting the plural version
+// of the name. If omitted, the name will have an s appended to generate its plural version.
+//
 // Register panics if it is called twice with the same Type.
-func Register(typ Type, mutable bool, name string) {
+func Register(typ Type, mutable bool, name string, options ...string) {
+	var plural *string
+
 	if _, ok := definitions[typ]; ok {
 		panic("Type already registered: " + string(typ))
 	}
-	definitions[typ] = definition{mutable, name}
+
+	if len(options) >= 1 {
+		plural = &options[0]
+	}
+
+	definitions[typ] = definition{
+		mutable: mutable,
+		name:    name,
+		plural:  plural,
+	}
 }
 
 // TypeFromString will return the type from a string interpretation of the type.
@@ -178,6 +203,7 @@ var definitions = map[Type]definition{}
 type definition struct {
 	mutable bool
 	name    string
+	plural  *string
 }
 
 func init() {
@@ -197,10 +223,7 @@ func init() {
 	Register(Product, true, "product")
 	Register(Plan, true, "plan")
 	Register(Region, true, "region")
-	// Id types are used to find the database table. It is not smart enough to know that the plural of category is
-	// categories and it tries to used the table `categorys`. See the `Collection()` method on `Type`.
-	// To fix this, we rename the registered type to `categorie` so `Collection()` returns `categories`
-	Register(Category, true, "categorie")
+	Register(Category, true, "category", "categories")
 
 	Register(Operation, true, "operation")
 	Register(Callback, true, "callback")

--- a/idtype/idtype.go
+++ b/idtype/idtype.go
@@ -197,7 +197,10 @@ func init() {
 	Register(Product, true, "product")
 	Register(Plan, true, "plan")
 	Register(Region, true, "region")
-	Register(Category, true, "category")
+	// Id types are used to find the database table. It is not smart enough to know that the plural of category is
+	// categories and it tries to used the table `categorys`. See the `Collection()` method on `Type`.
+	// To fix this, we rename the registered type to `categorie` so `Collection()` returns `categories`
+	Register(Category, true, "categorie")
 
 	Register(Operation, true, "operation")
 	Register(Callback, true, "callback")

--- a/idtype/idtype_test.go
+++ b/idtype/idtype_test.go
@@ -68,12 +68,22 @@ func TestType_Collection(t *testing.T) {
 		{
 			scenario: "access suffix",
 			typ: func() idtype.Type {
-				typ := idtype.Type(idtype.TypeOverflow - 1)
+				typ := idtype.Type(idtype.TypeOverflow - 2)
 				idtype.Register(typ, false, "things_access")
 
 				return typ
 			},
 			plural: "things_access",
+		},
+		{
+			scenario: "define plurals",
+			typ: func() idtype.Type {
+				typ := idtype.Type(idtype.TypeOverflow - 1)
+				idtype.Register(typ, false, "category", "categories")
+
+				return typ
+			},
+			plural: "categories",
 		},
 	}
 

--- a/idtype/idtype_test.go
+++ b/idtype/idtype_test.go
@@ -79,7 +79,7 @@ func TestType_Collection(t *testing.T) {
 			scenario: "define plurals",
 			typ: func() idtype.Type {
 				typ := idtype.Type(idtype.TypeOverflow - 1)
-				idtype.Register(typ, false, "category", "categories")
+				idtype.Register(typ, false, "category", idtype.WithPlural("categories"))
 
 				return typ
 			},


### PR DESCRIPTION
See the code for why this was necessary, the idtype's `Collection()` method is used to find the database table and its ability to find the table's name is very limited. Since the `Categories` table was our first table to not have a simple "add a s" plural name, we never noticed the issue.